### PR TITLE
Ignore macos .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ demo*_tmp/
 test_tmp/
 # ignore python bytecode
 *.pyc
-
+# ignore macos files
+.DS_Store


### PR DESCRIPTION
When the MacOS finder visits a directory it tends to create a file
called .DS_Store that describe how the directory should be displayed.
These files should not be viewed by git as they are just polluting the
repository.
