### PR TITLE
Fix issue with weblogo and large counts

### DIFF
--- a/PBlib.py
+++ b/PBlib.py
@@ -202,3 +202,34 @@ def write_fasta(name, seq, comment):
     f_out = open(name, "a")
     f_out.write(fasta_content)
     f_out.close()
+
+
+def count_to_transfac(identifier, count_content):
+    """
+    Convert a table of PB frequencies into transfac format
+    
+    http://meme.sdsc.edu/meme/doc/transfac-format.html
+
+    Parameters
+    ----------
+    identifier : str
+        Chain used for the ID property in the output.
+    count_content : 
+        Content of the count file outputed by PBcount as a list of lines.
+
+    Return
+    ------
+    The frequency matrix as a string in the transfac format.
+    """
+    residue_lst = []
+    transfac_content  = "ID %s\n" % identifier
+    transfac_content += "BF unknown\n"
+    transfac_content += "P0" + count_content[0][2:]
+    for line in count_content[1:]:
+        item = line.split()
+        residue = int(item[0])
+        residue_lst.append(residue)
+        transfac_content += "%05d " % residue + line[5:-1] +  "    X" + "\n"
+    transfac_content += "XX\n"
+    transfac_content += "//"
+    return transfac_content

--- a/PBstat.py
+++ b/PBstat.py
@@ -53,6 +53,7 @@ def array_to_string(ar):
     #  precision : float with 4 digits
     return numpy.array_str(ar, max_line_width = 100000, precision = 4).translate(None, '[]')
 
+
 #===============================================================================
 # MAIN - program starts here
 #===============================================================================
@@ -370,18 +371,7 @@ if options.logo:
 
     # convert a table of PB frequencies into transfac format as required by weblogo
     # http://meme.sdsc.edu/meme/doc/transfac-format.html
-    #-------------------------------------------------------------------------------
-    residue_lst = []
-    transfac_content  = "ID %s\n" % options.f
-    transfac_content += "BF unknown\n"
-    transfac_content += "P0" + count_content[0][2:]
-    for line in count_content[1:]:
-        item = line.split()
-        residue = int(item[0])
-        residue_lst.append(residue)
-        transfac_content += "%05d " % residue + line[5:-1] +  "    X" + "\n"
-    transfac_content += "XX\n"
-    transfac_content += "//"
+    transfac_content = PB.count_to_transfac(options.f, count_content)
 
     # write transfac file (debug only)
     #-------------------------------------------------------------------------------

--- a/PBstat.py
+++ b/PBstat.py
@@ -379,7 +379,7 @@ if options.logo:
         item = line.split()
         residue = int(item[0])
         residue_lst.append(residue)
-        transfac_content += "%05d" % residue + line[5:-1] +  "    X" + "\n"
+        transfac_content += "%05d " % residue + line[5:-1] +  "    X" + "\n"
     transfac_content += "XX\n"
     transfac_content += "//"
 

--- a/test_functions.py
+++ b/test_functions.py
@@ -170,6 +170,42 @@ class TestPBlib(unittest.TestCase):
         self.assertEqual(sequences, ['ZZdddfklonbfklmmmmmmmmnopafklnoiakl'
                                      'mmmmmnoopacddddddehkllmmmmngoilmmmm'
                                      'mmmmmmmmnopacdcddZZ'])
+
+    def test_count_to_transfac(self):
+        """
+        Test if the count_to_transfac function works.
+        """
+        ref_input = ['         a     b     c     d\n',  # header
+                     '1        0     0     0     0\n', 
+                     '2        2   789 99999    89\n',  # one value is written
+                                                        # on 5 characters
+                     '3    99999  8888     2     2\n',  # the first value is
+                                                        # written on 5 characters
+                     '4       99     0 999999     0\n', # one value is written
+                                                        # on more than 5
+                                                        # characters
+                     '5        0     0     0     0\n', 
+                    ]
+        identifier = 'identifier'
+        ref_output = ("ID identifier\n"
+                      "BF unknown\n"
+                      "P0       a     b     c     d\n"
+                      "00001     0     0     0     0    X\n"
+                      "00002     2   789 99999    89    X\n"
+                      "00003 99999  8888     2     2    X\n"
+                      "00004    99     0 999999     0    X\n"
+                      "00005     0     0     0     0    X\n"
+                      "XX\n"
+                      "//")
+        output = PB.count_to_transfac(identifier, ref_input)
+        ref_output_lines = ref_output.split('\n')
+        output_lines = output.split('\n')
+        self.assertEqual(len(ref_output_lines), len(output_lines),
+                         'Not the right number of lines')
+        for ref_line, line in zip(ref_output_lines, output_lines):
+            print('ref:', ref_line)
+            print('out:', line)
+            self.assertEqual(ref_line, line)
                                      
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If the first count of a line in PBcount output is greater than 9999, then the count is written on 5 characters. This causes the first count to be written right next to the residue number in the transfac file generated for weblogo. Therefore, the residue number and the first count are read as a single field by the weblogo transfac parser, and the number of read fields is wrong.

This pull request adds a single space after the residue number when writing a transfac file. As a consequence, the residue number and the first count cannot be read together as a single field anymore, whatever length is the first count. The pull request also moves the generation of transfac files from PBstat main body to a function in PBlib, and adds a test for this function in test_functions.

The change has been tested with the files provided by @sleonard0386 in issue #27 and with weblogo 3.4 (2014-06-02).

Because the fields are space separated already in the output of PBcount, the other fields do not have an issue when their value is large.

This commit may fix issue #27, yet the error message Sylvain reported seems to come from an earlier version of weblogo.