### PR TITLE
Make displayed and run command consistent in demo 1

### DIFF
--- a/run_demo1.sh
+++ b/run_demo1.sh
@@ -46,7 +46,7 @@ pause
 
 echo  -e "\n"
 echo "Test with 2LFU.pdb: RMN structure, 10 models"
-echo "../PBassign.py -f 2LFU.pdb -o 2LFU"
+echo "../PBassign.py -p 2LFU.pdb -o 2LFU"
 pause
 ../PBassign.py -p 2LFU.pdb -o 2LFU
 
@@ -61,7 +61,7 @@ echo "#------------------------------------------------------------------------#
 
 echo  -e "\n"
 echo "Test with 3ICH.pdb: RX structure, one chain"
-echo "../PBassign.py -f 3ICH.pdb -o 3ICH --phipsi"
+echo "../PBassign.py -p 3ICH.pdb -o 3ICH --phipsi"
 pause
 ../PBassign.py -p 3ICH.pdb -o 3ICH --phipsi
 
@@ -76,7 +76,7 @@ echo "#------------------------------------------------------------------------#
 
 echo  -e "\n"
 echo "Test with 2LFU.pdb: RMN structure, 10 models"
-echo "../PBassign.py -f 2LFU.pdb -o 2LFU --flat"
+echo "../PBassign.py -p 2LFU.pdb -o 2LFU --flat"
 pause
 ../PBassign.py -p 2LFU.pdb -o 2LFU --flat
 
@@ -90,7 +90,7 @@ echo "#------------------------------------------------------------------------#
 
 echo  -e "\n"
 echo "Test with several PDB files"
-echo "../PBassign.py -d ./ -o all"
+echo "../PBassign.py -p 3ICH.pdb -p 2LFU.pdb -o several"
 pause
 ../PBassign.py -p 3ICH.pdb -p 2LFU.pdb -o several
 
@@ -98,7 +98,7 @@ echo  -e "\n"
 echo "Test with all PDB files from a directory"
 echo "../PBassign.py -d ./ -o all"
 pause
-../PBassign.py -p ./ -o all
+../PBassign.py -d ./ -o all
 
 
 echo  -e "\n"

--- a/run_demo1.sh
+++ b/run_demo1.sh
@@ -96,9 +96,9 @@ pause
 
 echo  -e "\n"
 echo "Test with all PDB files from a directory"
-echo "../PBassign.py -d ./ -o all"
+echo "../PBassign.py -p ./ -o all"
 pause
-../PBassign.py -d ./ -o all
+../PBassign.py -p ./ -o all
 
 
 echo  -e "\n"


### PR DESCRIPTION
As repported by @sleonard0386 in issue #37, the commands displayed on the terminal and the commands that are actually run by run_demo1.sh are not consistent with each other.

This pull request update demo 1 so as the displayed command match what is actually run.

For the demo of PBassign working on a full directory, the displayed command was correct rather than the run one. Indeed, demo 1 used the ` -d` argument for PBassign to assign PB to all the files in a directory. This option does not exist. Instead, the `-p` option should be used; if the path given to PBassign with `-p` is a directory, then PBassign will work on all PDB and mmcif files in that directory.

Fix #37 