### PR TITLE
Move assignment logic to PBlib

### DIFF
--- a/PBassign.py
+++ b/PBassign.py
@@ -17,7 +17,6 @@ from __future__ import print_function
 ## standard modules
 import os
 import sys
-import math
 import glob
 import argparse 
 
@@ -187,7 +186,7 @@ if options.p:
 if not options.p:
     try:
         import MDAnalysis
-    except:
+    except ImportError:
         sys.exit("Error: failed to import MDAnalysis")
 
     model = ""

--- a/PBassign.py
+++ b/PBassign.py
@@ -43,15 +43,15 @@ except NameError:
     pass
 
 
-def PB_assign(pb_ref, structure, comment, options,
-              fasta_name, flat_name, phipsi_name):
+def PB_assign(pb_ref, structure, comment,
+              fasta_name, flat_name=None, phipsi_name=None):
     """assign Protein Blocks (PB) from phi and psi angles
     """
     # get phi and psi angles from structure
     dihedrals = structure.get_phi_psi_angles()
     #print(dihedrals)
     # write phi and psi angles
-    if options.phipsi:
+    if not phipsi_name is None:
         PB.write_phipsi(phipsi_name, dihedrals, comment)
 
     pb_seq = PB.assign(dihedrals, pb_ref)
@@ -60,7 +60,7 @@ def PB_assign(pb_ref, structure, comment, options,
     PB.write_fasta(fasta_name, pb_seq, comment)
     
     # write PBs in flat file
-    if options.flat:
+    if not flat_name is None:
         PB.write_flat(flat_name, pb_seq)
  
     print("PBs assigned for {0}".format(comment))
@@ -177,7 +177,7 @@ if options.p:
             if chain.name:
                 comment += " | chain %s" % (chain.name)
             # assign PBs
-            PB_assign(PB.REFERENCES, chain, comment, options,
+            PB_assign(PB.REFERENCES, chain, comment,
                       fasta_name=fasta_name, flat_name=flat_name,
                       phipsi_name=phipsi_name)
 
@@ -213,7 +213,7 @@ if not options.p:
                 comment = "%s | frame %s" % (options.x, ts.frame)
         # assign structure after end of frame
         if structure.size() != 0 :
-            PB_assign(PB.REFERENCES, structure, comment, options,
+            PB_assign(PB.REFERENCES, structure, comment,
                       fasta_name=fasta_name, flat_name=flat_name,
                       phipsi_name=phipsi_name)
 

--- a/PBassign.py
+++ b/PBassign.py
@@ -43,111 +43,6 @@ except NameError:
     pass
 
 
-
-#===============================================================================
-# functions
-#===============================================================================
-
-
-def angle_modulo_360(angle):
-    """keep angle in the range -180 / +180 [degrees]
-    """
-    if angle > 180.0:
-        return angle - 360.0
-    elif angle < -180.0:
-        return angle + 360.0
-    else:
-        return angle
-    
-#-------------------------------------------------------------------------------
-def write_phipsi(name, torsion, com):
-    """save phi and psi angles
-    """
-    f_out = open(name, "a")
-    for res in sorted(torsion):
-        try:
-            phi_str = "%8.2f" % torsion[res]["phi"]
-        except:
-            phi_str = "    None"
-        try:
-            psi_str = "%8.2f" % torsion[res]["psi"]
-        except:
-            psi_str = "    None"
-        f_out.write("%s %6d %s %s \n" % (com, res, phi_str, psi_str))
-    f_out.close()
-
-#-------------------------------------------------------------------------------
-def write_flat(name, seq):
-    """write flat sequence to file 
-    """
-    f_out = open(name, "a")
-    f_out.write(seq + "\n")
-    f_out.close()
-
-#-------------------------------------------------------------------------------
-def PB_assign(pb_ref, structure, comment):
-    """assign Protein Blocks (PB) from phi and psi angles
-    """
-    # get phi and psi angles from structure
-    dihedrals = structure.get_phi_psi_angles()
-    #print(dihedrals)
-    # write phi and psi angles
-    if options.phipsi:
-        write_phipsi(phipsi_name, dihedrals, comment)
-
-    pb_seq = ""
-    # iterate over all residues
-    for res in sorted(dihedrals):
-        angles = []
-        # try to get all eight angles required for PB assignement
-        try:
-            angles.append(dihedrals[res-2]["psi"])
-            angles.append(dihedrals[res-1]["phi"])
-            angles.append(dihedrals[res-1]["psi"])
-            angles.append(dihedrals[res  ]["phi"])
-            angles.append(dihedrals[res  ]["psi"])
-            angles.append(dihedrals[res+1]["phi"])
-            angles.append(dihedrals[res+1]["psi"])
-            angles.append(dihedrals[res+2]["phi"])
-            # check for bad angles 
-            # (error while calculating torsion: missing atoms)
-            if None in angles:
-                pb_seq += "Z"
-                continue 
-           
-        # cannot get required angles (Nter, Cter or missign residues)
-        # -> cannot assign PB
-        # jump to next residue
-        except:
-            pb_seq += "Z"
-            continue
-        
-        # convert to array
-        angles = numpy.array(angles)
-
-        # compare to reference PB angles
-        rmsda_lst = {}
-        for block in pb_ref:
-            diff = pb_ref[block] - angles
-            diff2 = angle_modulo_360_vect(diff)
-            rmsda = numpy.sum(diff2**2)
-            rmsda_lst[rmsda] = block
-        pb_seq += rmsda_lst[min(rmsda_lst)]
-
-    # write PBs in fasta file
-    PB.write_fasta(fasta_name, pb_seq, comment)
-    
-    # write PBs in flat file
-    if options.flat:
-        write_flat(flat_name, pb_seq)
- 
-    print("PBs assigned for {0}".format(comment))
-             
-#-------------------------------------------------------------------------------
-# vertorize function
-#-------------------------------------------------------------------------------
-angle_modulo_360_vect = numpy.vectorize(angle_modulo_360)
-
 #===============================================================================
 # MAIN - program starts here
 #===============================================================================
@@ -229,6 +124,7 @@ PB.clean_file(fasta_name)
 #-------------------------------------------------------------------------------
 # prepare phi psi file for output
 #-------------------------------------------------------------------------------
+phipsi_name = None
 if options.phipsi:
     phipsi_name = options.o + ".PB.phipsi"
     PB.clean_file(phipsi_name)
@@ -236,6 +132,7 @@ if options.phipsi:
 #-------------------------------------------------------------------------------
 # prepare flat file for output
 #-------------------------------------------------------------------------------
+flat_name = None
 if options.flat:
     flat_name = options.o + ".PB.flat"
     PB.clean_file(flat_name)
@@ -257,7 +154,9 @@ if options.p:
             if chain.name:
                 comment += " | chain %s" % (chain.name)
             # assign PBs
-            PB_assign(PB.REFERENCES, chain, comment)
+            PB.PB_assign(PB.REFERENCES, chain, comment, options,
+                         fasta_name=fasta_name, flat_name=flat_name,
+                         phipsi_name=phipsi_name)
 
 
 
@@ -291,7 +190,9 @@ if not options.p:
                 comment = "%s | frame %s" % (options.x, ts.frame)
         # assign structure after end of frame
         if structure.size() != 0 :
-            PB_assign(PB.REFERENCES, structure, comment)
+            PB.PB_assign(PB.REFERENCES, structure, comment, options,
+                         fasta_name=fasta_name, flat_name=flat_name,
+                         phipsi_name=phipsi_name)
 
 print( "wrote {0}".format(fasta_name) )
 if options.flat:

--- a/PBassign.py
+++ b/PBassign.py
@@ -43,6 +43,29 @@ except NameError:
     pass
 
 
+def PB_assign(pb_ref, structure, comment, options,
+              fasta_name, flat_name, phipsi_name):
+    """assign Protein Blocks (PB) from phi and psi angles
+    """
+    # get phi and psi angles from structure
+    dihedrals = structure.get_phi_psi_angles()
+    #print(dihedrals)
+    # write phi and psi angles
+    if options.phipsi:
+        PB.write_phipsi(phipsi_name, dihedrals, comment)
+
+    pb_seq = PB.assign(dihedrals, pb_ref)
+    
+    # write PBs in fasta file
+    PB.write_fasta(fasta_name, pb_seq, comment)
+    
+    # write PBs in flat file
+    if options.flat:
+        PB.write_flat(flat_name, pb_seq)
+ 
+    print("PBs assigned for {0}".format(comment))
+
+
 #===============================================================================
 # MAIN - program starts here
 #===============================================================================
@@ -154,9 +177,9 @@ if options.p:
             if chain.name:
                 comment += " | chain %s" % (chain.name)
             # assign PBs
-            PB.PB_assign(PB.REFERENCES, chain, comment, options,
-                         fasta_name=fasta_name, flat_name=flat_name,
-                         phipsi_name=phipsi_name)
+            PB_assign(PB.REFERENCES, chain, comment, options,
+                      fasta_name=fasta_name, flat_name=flat_name,
+                      phipsi_name=phipsi_name)
 
 
 
@@ -190,9 +213,9 @@ if not options.p:
                 comment = "%s | frame %s" % (options.x, ts.frame)
         # assign structure after end of frame
         if structure.size() != 0 :
-            PB.PB_assign(PB.REFERENCES, structure, comment, options,
-                         fasta_name=fasta_name, flat_name=flat_name,
-                         phipsi_name=phipsi_name)
+            PB_assign(PB.REFERENCES, structure, comment, options,
+                      fasta_name=fasta_name, flat_name=flat_name,
+                      phipsi_name=phipsi_name)
 
 print( "wrote {0}".format(fasta_name) )
 if options.flat:

--- a/PBassign.py
+++ b/PBassign.py
@@ -20,9 +20,6 @@ import sys
 import glob
 import argparse 
 
-## third-party module
-import numpy 
-
 ## local module
 import PBlib as PB
 import PDBlib as PDB

--- a/PBlib.py
+++ b/PBlib.py
@@ -15,7 +15,6 @@ from __future__ import print_function
 ## standard modules
 import os
 import sys
-import math
 
 ## third-party modules
 import numpy
@@ -258,7 +257,7 @@ def assign(dihedrals, pb_ref):
         # cannot get required angles (Nter, Cter or missign residues)
         # -> cannot assign PB
         # jump to next residue
-        except:
+        except KeyError:
             pb_seq += "Z"
             continue
         
@@ -294,11 +293,11 @@ def write_phipsi(name, torsion, com):
     for res in sorted(torsion):
         try:
             phi_str = "%8.2f" % torsion[res]["phi"]
-        except:
+        except TypeError:
             phi_str = "    None"
         try:
             psi_str = "%8.2f" % torsion[res]["psi"]
-        except:
+        except TypeError:
             psi_str = "    None"
         f_out.write("%s %6d %s %s \n" % (com, res, phi_str, psi_str))
     f_out.close()

--- a/PBlib.py
+++ b/PBlib.py
@@ -234,17 +234,7 @@ def count_to_transfac(identifier, count_content):
     return transfac_content
 
 
-def PB_assign(pb_ref, structure, comment, options,
-              fasta_name, flat_name, phipsi_name):
-    """assign Protein Blocks (PB) from phi and psi angles
-    """
-    # get phi and psi angles from structure
-    dihedrals = structure.get_phi_psi_angles()
-    #print(dihedrals)
-    # write phi and psi angles
-    if options.phipsi:
-        write_phipsi(phipsi_name, dihedrals, comment)
-
+def assign(dihedrals, pb_ref):
     pb_seq = ""
     # iterate over all residues
     for res in sorted(dihedrals):
@@ -283,7 +273,22 @@ def PB_assign(pb_ref, structure, comment, options,
             rmsda = numpy.sum(diff2**2)
             rmsda_lst[rmsda] = block
         pb_seq += rmsda_lst[min(rmsda_lst)]
+    return pb_seq
 
+
+def PB_assign(pb_ref, structure, comment, options,
+              fasta_name, flat_name, phipsi_name):
+    """assign Protein Blocks (PB) from phi and psi angles
+    """
+    # get phi and psi angles from structure
+    dihedrals = structure.get_phi_psi_angles()
+    #print(dihedrals)
+    # write phi and psi angles
+    if options.phipsi:
+        write_phipsi(phipsi_name, dihedrals, comment)
+
+    pb_seq = assign(dihedrals, pb_ref)
+    
     # write PBs in fasta file
     write_fasta(fasta_name, pb_seq, comment)
     

--- a/PBlib.py
+++ b/PBlib.py
@@ -234,6 +234,23 @@ def count_to_transfac(identifier, count_content):
 
 
 def assign(dihedrals, pb_ref):
+    """
+    Assign Protein Blocks.
+
+    Dihedral angles are provided as a dictionnary with one item per residue. The
+    key is the residue number, and the value is a dictionnary with phi and psi
+    as keys, and the dihedral angles as values.
+
+    The protein block definitions are provided as a dictionnary. Each key is a
+    block name, the values are lists of dihedral angles.
+
+    Parameters
+    ----------
+    dihedrals : dict
+        Phi and psi dihedral angles for each residue.
+    pb_ref : dict
+        The definition of the protein blocks.
+    """
     pb_seq = ""
     # iterate over all residues
     for res in sorted(dihedrals):

--- a/PBlib.py
+++ b/PBlib.py
@@ -276,29 +276,6 @@ def assign(dihedrals, pb_ref):
     return pb_seq
 
 
-def PB_assign(pb_ref, structure, comment, options,
-              fasta_name, flat_name, phipsi_name):
-    """assign Protein Blocks (PB) from phi and psi angles
-    """
-    # get phi and psi angles from structure
-    dihedrals = structure.get_phi_psi_angles()
-    #print(dihedrals)
-    # write phi and psi angles
-    if options.phipsi:
-        write_phipsi(phipsi_name, dihedrals, comment)
-
-    pb_seq = assign(dihedrals, pb_ref)
-    
-    # write PBs in fasta file
-    write_fasta(fasta_name, pb_seq, comment)
-    
-    # write PBs in flat file
-    if options.flat:
-        write_flat(flat_name, pb_seq)
- 
-    print("PBs assigned for {0}".format(comment))
-
-
 def angle_modulo_360(angle):
     """keep angle in the range -180 / +180 [degrees]
     """


### PR DESCRIPTION
Move the assignment logic from PBassign to PBlib. This makes possible to import PBlib and call the assignment function.

This is a first step toward the proposal #25.