### PR TITLE
Make PBcount more modular

### DIFF
--- a/PBcount.py
+++ b/PBcount.py
@@ -18,9 +18,6 @@ import os
 import sys
 import argparse
 
-## third-party module
-import numpy 
-
 ## local module
 import PBlib as PB
 
@@ -41,88 +38,70 @@ except NameError:
 # MAIN - program starts here
 #===============================================================================
 
-#-------------------------------------------------------------------------------
-# get options
-#-------------------------------------------------------------------------------
-parser = argparse.ArgumentParser(
-    description = 'Compute PB frequency along protein sequence.')
+def user_input():
+    #--------------------------------------------------------------------------
+    # get options
+    #--------------------------------------------------------------------------
+    parser = argparse.ArgumentParser(
+        description = 'Compute PB frequency along protein sequence.')
 
-# mandatory arguments
-parser.add_argument("-f", action="append", required = True,
-    help="name(s) of the PBs file (in fasta format)")
-parser.add_argument("-o", action="store", required = True,
-    help="name for results")
+    # mandatory arguments
+    parser.add_argument("-f", action="append", required = True,
+        help="name(s) of the PBs file (in fasta format)")
+    parser.add_argument("-o", action="store", required = True,
+        help="name for results")
 
 
-# optional arguments
-parser.add_argument("--first-residue", action="store", type=int,
-    dest = "first_residue", help="define first residue number (1 by default)")
+    # optional arguments
+    parser.add_argument("--first-residue", action="store", type=int, default=1,
+        dest = "first_residue", help="define first residue number (1 by default)")
 
-# get all arguments
-options = parser.parse_args()
+    # get all arguments
+    options = parser.parse_args()
 
-#-------------------------------------------------------------------------------
-# check options
-#-------------------------------------------------------------------------------
-if options.first_residue and options.first_residue < 1:
-    parser.error("first residue must be >= 1")
+    #--------------------------------------------------------------------------
+    # check options
+    #--------------------------------------------------------------------------
+    if options.first_residue and options.first_residue < 1:
+        parser.error("first residue must be >= 1")
 
-#-------------------------------------------------------------------------------
-# check input files
-#-------------------------------------------------------------------------------
-for name in options.f:
-    if not os.path.isfile(name):
-        sys.exit( "{0}: not a valid file. Bye.".format(name) )
-    
-#-------------------------------------------------------------------------------
-# read PBs files
-#-------------------------------------------------------------------------------
-pb_seq = []
-pb_name = []
-for name in options.f:
-    header, seq = PB.read_fasta(name)
-    pb_name += header
-    pb_seq += seq
+    #--------------------------------------------------------------------------
+    # check input files
+    #--------------------------------------------------------------------------
+    for name in options.f:
+        if not os.path.isfile(name):
+            sys.exit( "{0}: not a valid file. Bye.".format(name) )
 
-#-------------------------------------------------------------------------------
-# check all sequences have the same size
-#-------------------------------------------------------------------------------
-pb_seq_size = len(pb_seq[0])
-for seq in pb_seq:
-    if len(seq) != pb_seq_size:
+    return options
+
+
+def main():
+    options = user_input()
+
+    #-------------------------------------------------------------------------------
+    # read PBs files
+    #-------------------------------------------------------------------------------
+    pb_name, pb_seq = PB.read_several_fasta(options.f)
+
+    #-------------------------------------------------------------------------------
+    # count PBs at each position of the sequence
+    #-------------------------------------------------------------------------------
+    try:
+        pb_count = PB.count_matrix(pb_seq)
+    except PB.SizeError:
         sys.exit("cannot compute PB frequencies / different sequence lengths")
+    except PB.InvalidBlockError:
+        msg = "{0} is not a valid protein block (abcdefghijklmnop)".format
+        sys.exit( msg(block) )
 
-#-------------------------------------------------------------------------------
-# count PBs at each position of the sequence
-#-------------------------------------------------------------------------------
-pb_count = numpy.zeros((pb_seq_size, len(PB.NAMES)))
+    #-------------------------------------------------------------------------------
+    # write PBs count file
+    #-------------------------------------------------------------------------------
+    count_file_name = options.o + ".PB.count"
+    with open(count_file_name, 'w') as outfile:
+        PB.write_count_matrix(pb_count, outfile, options.first_residue)
+    print( "wrote {0}".format(count_file_name) )
 
-for seq in pb_seq:
-    for idx, block in enumerate(seq):
-        if block in PB.NAMES:
-            pb_count[idx, PB.NAMES.index(block)] += 1.0
-        elif block not in ["Z", "z"]:
-            msg = "{0} is not a valid protein block (abcdefghijklmnop)".format
-            sys.exit( msg(block) )
 
-#-------------------------------------------------------------------------------
-# write PBs count file
-#-------------------------------------------------------------------------------
-first = 1
-if options.first_residue:
-    first = options.first_residue
-    print( "first residue will be numbered {0}".format(first) )
-
-count_file_name = options.o + ".PB.count"
-content = "    "
-# build header (PB names)
-content += "".join(["%6s" % name for name in PB.NAMES]) + "\n"
-# build data table
-for residue_idx, residue_pb in enumerate(pb_count):
-    content += "%-5d" % (residue_idx + first) + " ".join("%5d" % i for i in residue_pb) + "\n"
-# write data
-count_file = open(count_file_name, "w")
-count_file.write(content)
-count_file.close()
-print( "wrote {0}".format(count_file_name) )
-
+if __name__ == '__main__':
+    main()

--- a/PBcount.py
+++ b/PBcount.py
@@ -4,12 +4,12 @@
 """
 Compute PB frequency along protein sequence.
 
-2013 - P. Poulain, A. G. de Brevern 
+2013 - P. Poulain, A. G. de Brevern
 """
 
-#===============================================================================
+#==============================================================================
 # Modules
-#===============================================================================
+#==============================================================================
 ## Use print as a function for python 3 compatibility
 from __future__ import print_function
 
@@ -21,9 +21,9 @@ import argparse
 ## local module
 import PBlib as PB
 
-#===============================================================================
+#==============================================================================
 # Python2/Python3 compatibility
-#===============================================================================
+#==============================================================================
 
 # The range function in python 3 behaves as the range function in python 2
 # and returns a generator rather than a list. To produce a list in python 3,
@@ -34,43 +34,43 @@ try:
 except NameError:
     pass
 
-#===============================================================================
+#==============================================================================
 # MAIN - program starts here
-#===============================================================================
+#==============================================================================
+
 
 def user_input():
-    #--------------------------------------------------------------------------
-    # get options
-    #--------------------------------------------------------------------------
+    """
+    Handle the user parameters for PBcount.
+
+    Returns
+    -------
+
+    The parsed arguments as parsed by `argparse`.
+    """
     parser = argparse.ArgumentParser(
-        description = 'Compute PB frequency along protein sequence.')
-
+        description='Compute PB frequency along protein sequence.')
     # mandatory arguments
-    parser.add_argument("-f", action="append", required = True,
-        help="name(s) of the PBs file (in fasta format)")
-    parser.add_argument("-o", action="store", required = True,
-        help="name for results")
-
-
+    parser.add_argument("-f", action="append", required=True,
+                        help="name(s) of the PBs file (in fasta format)")
+    parser.add_argument("-o", action="store", required=True,
+                        help="name for results")
     # optional arguments
     parser.add_argument("--first-residue", action="store", type=int, default=1,
-        dest = "first_residue", help="define first residue number (1 by default)")
+                        dest="first_residue",
+                        help="define first residue number (1 by default)")
 
-    # get all arguments
+    # parse the arguments
     options = parser.parse_args()
 
-    #--------------------------------------------------------------------------
     # check options
-    #--------------------------------------------------------------------------
     if options.first_residue and options.first_residue < 1:
         parser.error("first residue must be >= 1")
 
-    #--------------------------------------------------------------------------
     # check input files
-    #--------------------------------------------------------------------------
     for name in options.f:
         if not os.path.isfile(name):
-            sys.exit( "{0}: not a valid file. Bye.".format(name) )
+            sys.exit("{0}: not a valid file. Bye.".format(name))
 
     return options
 
@@ -78,25 +78,19 @@ def user_input():
 def main():
     options = user_input()
 
-    #-------------------------------------------------------------------------------
     # read PBs files
-    #-------------------------------------------------------------------------------
     pb_name, pb_seq = PB.read_several_fasta(options.f)
 
-    #-------------------------------------------------------------------------------
     # count PBs at each position of the sequence
-    #-------------------------------------------------------------------------------
     try:
         pb_count = PB.count_matrix(pb_seq)
     except PB.SizeError:
         sys.exit("cannot compute PB frequencies / different sequence lengths")
-    except PB.InvalidBlockError:
-        msg = "{0} is not a valid protein block (abcdefghijklmnop)".format
-        sys.exit( msg(block) )
+    except PB.InvalidBlockError as e:
+        msg = "'{0}' is not a valid protein block (abcdefghijklmnop)".format
+        sys.exit(msg(e.block))
 
-    #-------------------------------------------------------------------------------
     # write PBs count file
-    #-------------------------------------------------------------------------------
     count_file_name = options.o + ".PB.count"
     with open(count_file_name, 'w') as outfile:
         PB.write_count_matrix(pb_count, outfile, options.first_residue)

--- a/PBlib.py
+++ b/PBlib.py
@@ -91,7 +91,14 @@ class InvalidBlockError(ValueError):
     """
     Exception raised when encounter an invalid protein block.
     """
-    pass
+    def __init__(self, block=None):
+        self.block = block
+
+    def __repr__(self):
+        if block is None:
+            return "Invald block"
+        else:
+            return "Ivalid block '{}'".format(self.block)
 
 #===============================================================================
 # Functions
@@ -155,6 +162,20 @@ def read_fasta(name):
 
 
 def read_several_fasta(input_files):
+    """
+    Read several fasta files
+
+    Note that each fasta file may contain several sequences.
+
+    Parameters
+    ----------
+    input_files: a list of fasta file paths.
+
+    Returns
+    -------
+    pb_name: a list of the headers
+    pb_seq: a list of the sequences
+    """
     pb_seq = []
     pb_name = []
     for name in input_files:
@@ -165,6 +186,17 @@ def read_several_fasta(input_files):
 
 
 def assert_same_size(sequences):
+    """
+    Raise an exception is all sequence are not the same length.
+
+    Parameters
+    ----------
+    sequences: a list of sequences
+
+    Exceptions
+    ----------
+    SizeError: not all the sequences are the same length.
+    """
     seq_size = len(sequences[0])
     for seq in sequences:
         if len(seq) != seq_size:
@@ -363,6 +395,20 @@ def write_flat(name, seq):
 
 
 def count_matrix(pb_seq):
+    """
+    Count the occurences of each block at each position.
+
+    The occurence matrix has one row per sequence, and one column per block.
+    The columns are ordered in as PB.NAMES.
+
+    Parameters
+    ----------
+    pb_seq: a list of PB sequences.
+
+    Returns
+    -------
+    The occurence matrix.
+    """
     assert_same_size(pb_seq)
     pb_count = numpy.zeros((len(pb_seq[0]),  len(NAMES)))
     for seq in pb_seq:
@@ -370,11 +416,20 @@ def count_matrix(pb_seq):
             if block in NAMES:
                 pb_count[idx, NAMES.index(block)] += 1.0
             elif block not in ["Z", "z"]:
-                raise InvalidBlockError
+                raise InvalidBlockError(block=block)
     return pb_count
 
 
 def write_count_matrix(pb_count, outfile, first=1):
+    """
+    Write a PB occurence matrix in a file.
+
+    Parameters
+    ----------
+    pb_count: an occurence matrix as a 2D numpy array.
+    outfile: an open file where to write the matrix.
+    first: the residue number of the first position.
+    """
     # write the header (PB names)
     print("    " + "".join(["%6s" % name for name in NAMES]), file=outfile)
     # write the data table


### PR DESCRIPTION

This pull request divides `PBcount` into functions. It also move the generic functions to PBlib. Thus, this pull request improves PBxplore modularity, and makes the calculation of an occurence matrix available from the library. This improved modularity is a step toward the #25 proposal.

Note that this pull request expect the pull request #48 to be merged, even if there is not a strict dependency. Indeed, #48 defines regression tests for PBcount, and these tests should pass with the changes introduced here.

Four new functions appear in PBlib:

* `read_several_fasta` reads several fasta files, the path to which are given in parameters;
* `assert_same_size` raises a `SizeError` exception when all the sequences in a list are not of the same length;
* `count_matrix` computes an occurence matrix from a list of sequences;
* `write_count_matrix` writes an occurence matrix in a file.

In addition to these functions, the pull request introduces two new exceptions:

* `SizeError` is raised when a sequence does not have the expected length;
* `InvalidBlockError` is raised when a function encounter an unexpected block.

It is now possible to read a PDB file, to assign the corresponding PB sequence, and to calculate an occurence matrix using the PBxplore python library:

```python
import PDBlib as PDB
import PBlib as PB
pb_seq = []
pdb = PDB.PDB('demo1/2LFU.pdb')
for chain in pdb.get_chains():
    dihedrals = chain.get_phi_psi_angles()
    pb_seq.append(PB.assign(dihedrals,
                            PB.REFERENCES))
pb_count = PB.count_matrix(pb_seq)
```

In the exemple above, `pb_seq` is the list of the PB sequence for each model in `2LFU.pdb`, and `pb_count` is the corresponding occurence matrix. In the occurence matrix, each row corresponds to a position, and each column corresponds to a PB (in alphabetical order).