### PR TITLE
Check weblogo is available in PBstat.py

### DIFF
--- a/run_demo2.sh
+++ b/run_demo2.sh
@@ -88,13 +88,13 @@ echo "#------------------------------------------------------------------------#
 echo  -e "\n"
 echo "../PBstat.py -f psi_md_traj.PB.count -o psi_md_traj --map --neq --logo"
 pause
-../PBstat.py -f psi_md_traj_all.PB.count -o psi_md_traj --map --neq --logo
+../PBstat.py -f psi_md_traj_all.PB.count -o psi_md_traj --map --neq --logo || echo 'The command failed, is weblogo installed?'
 
 echo  -e "\n"
 echo "Define a residue frame (--residue-min and --residue-max options)"
 echo "../PBstat.py -f psi_md_traj.PB.count -o psi_md_traj --map --neq --logo --residue-min 10 --residue-max 30"
 pause
-../PBstat.py -f psi_md_traj_all.PB.count -o psi_md_traj --map --neq --logo --residue-min 10 --residue-max 30
+../PBstat.py -f psi_md_traj_all.PB.count -o psi_md_traj --map --neq --logo --residue-min 10 --residue-max 30 || echo 'The command failed, is weblogo installed?'
 
 
 echo  -e "\n"


### PR DESCRIPTION
This PR aims to solve the issue #60.

The availability of the weblogo program is now tested during the parsing step when the `--logo` option is set.

Since it's not possible to add a callback with a `store_true`action, I created a custom action class (`CommandAction`). The docstring of this class is pretty straightforward to understand how it works.
Basically, it behaves the same way as the `store_true` but add 2 new keywords:
 - command: the name (and it's possible arguments) of the external program to test (here `weblogo --help`)
 - cmd_help: to print a useful message (here, a link to the documentation) when the external program is not found (here weblogo).

The test of the availability is done through the subprocess library with the `cmd_exists` function which is called by `CommandAction`.
This class can be used for any external program, then it can be useful for R for example.

From #60, I choose to prevent `PBstat.py` to run if the `--logo` option is set and weblogo is not found by raising a exception which will be handle automatically by argparse.
I think it's better to stop the script than silent the error.