### PR TITLE
Improve PBassign modularity

### DIFF
--- a/PBassign.py
+++ b/PBassign.py
@@ -78,6 +78,11 @@ def PB_assign(pb_ref, structure, comment,
 
 
 def user_inputs():
+    """
+    Handle the user parameter from the command line
+
+    Parse the command line parameter and build the list of input files.
+    """
     parser = argparse.ArgumentParser(
         description='Read PDB structures and assign protein blocs (PBs).')
 
@@ -139,6 +144,9 @@ def user_inputs():
 
 
 def pbassign_cli():
+    """
+    PBassign command line.
+    """
     options, pdb_name_lst = user_inputs()
 
     if options.p:

--- a/PBassign.py
+++ b/PBassign.py
@@ -179,9 +179,9 @@ def pbassign_cli():
 
     with fasta_file, phipsi_file, flat_file:
         for comment, chain in chains:
-                PB_assign(PB.REFERENCES, chain, comment,
-                          fasta_file=fasta_file, flat_file=flat_file,
-                          phipsi_file=phipsi_file)
+            PB_assign(PB.REFERENCES, chain, comment,
+                      fasta_file=fasta_file, flat_file=flat_file,
+                      phipsi_file=phipsi_file)
 
     print("wrote {0}".format(fasta_name))
     if options.flat:

--- a/PBassign.py
+++ b/PBassign.py
@@ -75,7 +75,7 @@ def user_inputs():
     # arguments
     parser.add_argument("-p", action="append",
                         help=("name of a pdb file "
-                              "or name of a directory containing pdb files")
+                              "or name of a directory containing pdb files"))
     parser.add_argument("-o", action="store", required=True,
                         help="name for results")
     # arguments for MDanalysis

--- a/PBassign.py
+++ b/PBassign.py
@@ -42,6 +42,9 @@ except NameError:
 
 
 class _NullContext(object):
+    """
+    Dummy context manager that does nothing
+    """
     def __enter__(self):
         pass
 
@@ -50,21 +53,27 @@ class _NullContext(object):
 
 
 def PB_assign(pb_ref, structure, comment,
-              fasta_file, flat_file=_NullContext(), phipsi_file=_NullContext()):
-    """assign Protein Blocks (PB) from phi and psi angles
+              fasta_file=None, flat_file=None, phipsi_file=None):
+    """
+    Assign Protein Blocks (PB) from phi and psi angles
+
+    `fasta_file`, `flat_file`, and `phipsi_file` should be set to an open file
+    if an entry should be written is the file or to None or an instance of
+    _NullContext if no entry should be written.
     """
     dihedrals = structure.get_phi_psi_angles()
     pb_seq = PB.assign(dihedrals, pb_ref)
 
     # write PBs in fasta file
-    PB.write_fasta_entry(fasta_file, pb_seq, comment)
+    if not (isinstance(fasta_file, _NullContext) or fasta_file is None):
+        PB.write_fasta_entry(fasta_file, pb_seq, comment)
     # write phi and psi angles
-    if not isinstance(phipsi_file, _NullContext):
+    if not (isinstance(phipsi_file, _NullContext) or phipsi_file is None):
         PB.write_phipsi_entry(phipsi_file, dihedrals, comment)
     # write PBs in flat file
-    if not isinstance(flat_file, _NullContext):
+    if not (isinstance(flat_file, _NullContext) or flat_file is None):
         print(pb_seq, file=flat_file)
- 
+
     print("PBs assigned for {0}".format(comment))
 
 

--- a/PBassign.py
+++ b/PBassign.py
@@ -4,7 +4,7 @@
 """
 Read PDB structures and assign protein blocs (PBs).
 
-2013 - P. Poulain, A. G. de Brevern 
+2013 - P. Poulain, A. G. de Brevern
 """
 
 
@@ -15,7 +15,7 @@ from __future__ import print_function
 import os
 import sys
 import glob
-import argparse 
+import argparse
 
 ## local module
 import PBlib as PB
@@ -53,18 +53,14 @@ def PB_assign(pb_ref, structure, comment,
               fasta_file, flat_file=_NullContext(), phipsi_file=_NullContext()):
     """assign Protein Blocks (PB) from phi and psi angles
     """
-    # get phi and psi angles from structure
     dihedrals = structure.get_phi_psi_angles()
-    #print(dihedrals)
+    pb_seq = PB.assign(dihedrals, pb_ref)
+
+    # write PBs in fasta file
+    PB.write_fasta_entry(fasta_file, pb_seq, comment)
     # write phi and psi angles
     if not isinstance(phipsi_file, _NullContext):
         PB.write_phipsi_entry(phipsi_file, dihedrals, comment)
-
-    pb_seq = PB.assign(dihedrals, pb_ref)
-    
-    # write PBs in fasta file
-    PB.write_fasta_entry(fasta_file, pb_seq, comment)
-    
     # write PBs in flat file
     if not isinstance(flat_file, _NullContext):
         print(pb_seq, file=flat_file)
@@ -74,26 +70,28 @@ def PB_assign(pb_ref, structure, comment,
 
 def user_inputs():
     parser = argparse.ArgumentParser(
-        description = 'Read PDB structures and assign protein blocs (PBs).')
+        description='Read PDB structures and assign protein blocs (PBs).')
 
     # arguments
     parser.add_argument("-p", action="append",
-        help="name of a pdb file or name of a directory containing pdb files")
-    parser.add_argument("-o", action="store", required = True,
-        help="name for results")
+                        help=("name of a pdb file "
+                              "or name of a directory containing pdb files")
+    parser.add_argument("-o", action="store", required=True,
+                        help="name for results")
     # arguments for MDanalysis
     group = parser.add_argument_group(
         title='other options [if MDanalysis module is available]')
-    group.add_argument("-x", action="store", 
-        help="name of xtc file (Gromacs)")
-    group.add_argument("-g", action="store", 
-        help="name of gro file (Gromacs)")
+    group.add_argument("-x", action="store",
+                       help="name of xtc file (Gromacs)")
+    group.add_argument("-g", action="store",
+                       help="name of gro file (Gromacs)")
     # optional arguments
     parser.add_argument("--phipsi", action="store_true", default=False,
-        help="writes phi and psi angle")
+                        help="writes phi and psi angle")
     parser.add_argument("--flat", action="store_true", default=False,
-        help="writes one PBs sequence per line")
-    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.0')
+                        help="writes one PBs sequence per line")
+    parser.add_argument('-v', '--version', action='version',
+                        version='%(prog)s 1.0')
     # get all arguments
     options = parser.parse_args()
 
@@ -122,7 +120,7 @@ def user_inputs():
             # input is not a file neither a directory: say it
             elif (not os.path.isfile(name) or not os.path.isdir(name)):
                 parser.error("{0}: not a valid file or directory".format(name))
-    else:   
+    else:
         if not os.path.isfile(options.x):
             sys.exit("{0}: not a valid file".format(options.x))
         elif not os.path.isfile(options.g):
@@ -134,7 +132,7 @@ def user_inputs():
 def pbassign_cli():
     options, pdb_name_lst = user_inputs()
 
-    if options.p :
+    if options.p:
         if pdb_name_lst:
             print("{} PDB file(s) to process".format(len(pdb_name_lst)))
         else:
@@ -161,18 +159,18 @@ def pbassign_cli():
     else:
         # PB assignement of a Gromacs trajectory
         chains = PDB.chains_from_trajectory(options.x, options.g)
-    
+
     with fasta_file, phipsi_file, flat_file:
         for comment, chain in chains:
                 PB_assign(PB.REFERENCES, chain, comment,
                           fasta_file=fasta_file, flat_file=flat_file,
                           phipsi_file=phipsi_file)
 
-    print( "wrote {0}".format(fasta_name) )
+    print("wrote {0}".format(fasta_name))
     if options.flat:
-        print( "wrote {0}".format(flat_name) )
+        print("wrote {0}".format(flat_name))
     if options.phipsi:
-        print( "wrote {0}".format(phipsi_name) )
+        print("wrote {0}".format(phipsi_name))
 
 if __name__ == '__main__':
     pbassign_cli()

--- a/PBassign.py
+++ b/PBassign.py
@@ -8,9 +8,6 @@ Read PDB structures and assign protein blocs (PBs).
 """
 
 
-#===============================================================================
-# Modules
-#===============================================================================
 ## Use print as a function for python 3 compatibility
 from __future__ import print_function
 
@@ -24,11 +21,16 @@ import argparse
 import PBlib as PB
 import PDBlib as PDB
 
+# MDAnalysis is an optional requirement
+try:
+    import MDAnalysis
+except ImportError:
+    IS_MDANALYSIS = False
+else:
+    IS_MDANALYSIS = True
 
-#===============================================================================
-# Python2/Python3 compatibility
-#===============================================================================
 
+## Python2/Python3 compatibility
 # The range function in python 3 behaves as the range function in python 2
 # and returns a generator rather than a list. To produce a list in python 3,
 # one should use list(range). Here we change range to behave the same in
@@ -39,183 +41,138 @@ except NameError:
     pass
 
 
+class _NullContext(object):
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+
 def PB_assign(pb_ref, structure, comment,
-              fasta_name, flat_name=None, phipsi_name=None):
+              fasta_file, flat_file=_NullContext(), phipsi_file=_NullContext()):
     """assign Protein Blocks (PB) from phi and psi angles
     """
     # get phi and psi angles from structure
     dihedrals = structure.get_phi_psi_angles()
     #print(dihedrals)
     # write phi and psi angles
-    if not phipsi_name is None:
-        PB.write_phipsi(phipsi_name, dihedrals, comment)
+    if not isinstance(phipsi_file, _NullContext):
+        PB.write_phipsi_entry(phipsi_file, dihedrals, comment)
 
     pb_seq = PB.assign(dihedrals, pb_ref)
     
     # write PBs in fasta file
-    PB.write_fasta(fasta_name, pb_seq, comment)
+    PB.write_fasta_entry(fasta_file, pb_seq, comment)
     
     # write PBs in flat file
-    if not flat_name is None:
-        PB.write_flat(flat_name, pb_seq)
+    if not isinstance(flat_file, _NullContext):
+        print(pb_seq, file=flat_file)
  
     print("PBs assigned for {0}".format(comment))
 
 
-#===============================================================================
-# MAIN - program starts here
-#===============================================================================
+def user_inputs():
+    parser = argparse.ArgumentParser(
+        description = 'Read PDB structures and assign protein blocs (PBs).')
 
-#-------------------------------------------------------------------------------
-# manage parameters
-#-------------------------------------------------------------------------------
-parser = argparse.ArgumentParser(
-    description = 'Read PDB structures and assign protein blocs (PBs).')
+    # arguments
+    parser.add_argument("-p", action="append",
+        help="name of a pdb file or name of a directory containing pdb files")
+    parser.add_argument("-o", action="store", required = True,
+        help="name for results")
+    # arguments for MDanalysis
+    group = parser.add_argument_group(
+        title='other options [if MDanalysis module is available]')
+    group.add_argument("-x", action="store", 
+        help="name of xtc file (Gromacs)")
+    group.add_argument("-g", action="store", 
+        help="name of gro file (Gromacs)")
+    # optional arguments
+    parser.add_argument("--phipsi", action="store_true", default=False,
+        help="writes phi and psi angle")
+    parser.add_argument("--flat", action="store_true", default=False,
+        help="writes one PBs sequence per line")
+    parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.0')
+    # get all arguments
+    options = parser.parse_args()
 
-# arguments
-parser.add_argument("-p", action="append",
-    help="name of a pdb file or name of a directory containing pdb files")
-parser.add_argument("-o", action="store", required = True,
-    help="name for results")
+    # check options
+    if not options.p:
+        if not IS_MDANALYSIS:
+            parser.error("MDAnalysis is not installed; options -x and -d are not available")
+        if not options.x:
+            parser.print_help()
+            parser.error("use at least option -p or -x")
+        elif not options.g:
+            parser.print_help()
+            parser.error("option -g is mandatory, with use of option -x")
 
-# arguments for MDanalysis
-group = parser.add_argument_group(
-    title='other options [if MDanalysis module is available]')
-group.add_argument("-x", action="store", 
-    help="name of xtc file (Gromacs)")
-group.add_argument("-g", action="store", 
-    help="name of gro file (Gromacs)")
+    # check files
+    pdb_name_lst = []
+    if options.p:
+        for name in options.p:
+            # input is a file: store file name
+            if os.path.isfile(name):
+                pdb_name_lst.append(name)
+            # input is a directory: list and store all PDB and PDBx/mmCIF files
+            elif os.path.isdir(name):
+                for extension in (PDB.PDB_EXTENSIONS + PDB.PDBx_EXTENSIONS):
+                    pdb_name_lst += glob.glob(os.path.join(name, "*" + extension))
+            # input is not a file neither a directory: say it
+            elif (not os.path.isfile(name) or not os.path.isdir(name)):
+                parser.error("{0}: not a valid file or directory".format(name))
+    else:   
+        if not os.path.isfile(options.x):
+            sys.exit("{0}: not a valid file".format(options.x))
+        elif not os.path.isfile(options.g):
+            sys.exit("{0}: not a valid file".format(options.g))
 
-# optional arguments
-parser.add_argument("--phipsi", action="store_true", default=False,
-    help="writes phi and psi angle")
-parser.add_argument("--flat", action="store_true", default=False,
-    help="writes one PBs sequence per line")
-parser.add_argument('-v', '--version', action='version', version='%(prog)s 1.0')
-
-# get all arguments
-options = parser.parse_args()
-
-# check options
-if not options.p:
-    if not options.x:
-        parser.print_help()
-        parser.error("use at least option -p or -x")
-    elif not options.g:
-        parser.print_help()
-        parser.error("option -g is mandatory, with use of option -x")
+    return options, pdb_name_lst
 
 
-#-------------------------------------------------------------------------------
-# check files
-#-------------------------------------------------------------------------------
-pdb_name_lst = []
-if options.p:
-    for name in options.p:
-        # input is a file: store file name
-        if os.path.isfile(name):
-            pdb_name_lst.append(name)
-        # input is a directory: list and store all PDB and PDBx/mmCIF files
-        elif os.path.isdir(name):
-            for extension in (PDB.PDB_EXTENSIONS + PDB.PDBx_EXTENSIONS):
-                pdb_name_lst += glob.glob(os.path.join(name,  "*" + extension))
-        # input is not a file neither a directory: say it
-        elif (not os.path.isfile(name) or not os.path.isdir(name)):
-            print("{0}: not a valid file or directory".format(name))
-    
-    if pdb_name_lst:
-        print("{0} PDB file(s) to process".format( len(pdb_name_lst) ))
+def pbassign_cli():
+    options, pdb_name_lst = user_inputs()
+
+    if options.p :
+        if pdb_name_lst:
+            print("{} PDB file(s) to process".format(len(pdb_name_lst)))
+        else:
+            print('Nothing to do. Good bye.')
+            return
+
+    # prepare fasta file for output
+    fasta_name = options.o + ".PB.fasta"
+    fasta_file = open(fasta_name, 'w')
+    # prepare phi psi file for output
+    phipsi_file = _NullContext()
+    if options.phipsi:
+        phipsi_name = options.o + ".PB.phipsi"
+        phipsi_file = open(phipsi_name, 'w')
+    # prepare flat file for output
+    flat_file = _NullContext()
+    if options.flat:
+        flat_name = options.o + ".PB.flat"
+        flat_file = open(flat_name, 'w')
+
+    if options.p:
+        # PB assignement of PDB structures
+        chains = PDB.chains_from_files(pdb_name_lst)
     else:
-        sys.exit("Nothing to do. Bye.")
-else:   
-    if not os.path.isfile(options.x):
-        sys.exit("{0}: not a valid file".format(options.x))
-    elif not os.path.isfile(options.g):
-        sys.exit("{0}: not a valid file".format(options.g))
+        # PB assignement of a Gromacs trajectory
+        chains = PDB.chains_from_trajectory(options.x, options.g)
+    
+    with fasta_file, phipsi_file, flat_file:
+        for comment, chain in chains:
+                PB_assign(PB.REFERENCES, chain, comment,
+                          fasta_file=fasta_file, flat_file=flat_file,
+                          phipsi_file=phipsi_file)
 
+    print( "wrote {0}".format(fasta_name) )
+    if options.flat:
+        print( "wrote {0}".format(flat_name) )
+    if options.phipsi:
+        print( "wrote {0}".format(phipsi_name) )
 
-#-------------------------------------------------------------------------------
-# prepare fasta file for output
-#-------------------------------------------------------------------------------
-fasta_name = options.o + ".PB.fasta"
-PB.clean_file(fasta_name)
-
-#-------------------------------------------------------------------------------
-# prepare phi psi file for output
-#-------------------------------------------------------------------------------
-phipsi_name = None
-if options.phipsi:
-    phipsi_name = options.o + ".PB.phipsi"
-    PB.clean_file(phipsi_name)
- 
-#-------------------------------------------------------------------------------
-# prepare flat file for output
-#-------------------------------------------------------------------------------
-flat_name = None
-if options.flat:
-    flat_name = options.o + ".PB.flat"
-    PB.clean_file(flat_name)
-
-#-------------------------------------------------------------------------------
-# read PDB files
-#-------------------------------------------------------------------------------
-
-
-# PB assignement of PDB structures
-if options.p:
-    for pdb_name in pdb_name_lst:
-        pdb = PDB.PDB(pdb_name)
-        for chain in pdb.get_chains():
-            # build comment 
-            comment = pdb_name 
-            if chain.model:
-                comment += " | model %s" % (chain.model)
-            if chain.name:
-                comment += " | chain %s" % (chain.name)
-            # assign PBs
-            PB_assign(PB.REFERENCES, chain, comment,
-                      fasta_name=fasta_name, flat_name=flat_name,
-                      phipsi_name=phipsi_name)
-
-
-
-# PB assignement of a Gromacs trajectory
-if not options.p:
-    try:
-        import MDAnalysis
-    except ImportError:
-        sys.exit("Error: failed to import MDAnalysis")
-
-    model = ""
-    chain = ""
-    comment = ""
-
-    conf = options.g
-    traj = options.x
-
-    universe = MDAnalysis.Universe(conf, traj)
-
-    for ts in universe.trajectory:
-        structure = PDB.Chain()
-        selection = universe.selectAtoms("backbone")
-        for atm in selection:
-            atom = PDB.Atom()
-            atom.read_from_xtc(atm)
-            # append structure with atom
-            structure.add_atom(atom)
-            # define structure comment
-            # when the structure contains 1 atom
-            if structure.size() == 1:
-                comment = "%s | frame %s" % (options.x, ts.frame)
-        # assign structure after end of frame
-        if structure.size() != 0 :
-            PB_assign(PB.REFERENCES, structure, comment,
-                      fasta_name=fasta_name, flat_name=flat_name,
-                      phipsi_name=phipsi_name)
-
-print( "wrote {0}".format(fasta_name) )
-if options.flat:
-    print( "wrote {0}".format(flat_name) )
-if options.phipsi:
-    print( "wrote {0}".format(phipsi_name) )
-
+if __name__ == '__main__':
+    pbassign_cli()

--- a/PBassign.py
+++ b/PBassign.py
@@ -66,10 +66,10 @@ def PB_assign(pb_ref, structure, comment,
 
     # write PBs in fasta file
     if not (isinstance(fasta_file, _NullContext) or fasta_file is None):
-        PB.write_fasta_entry(fasta_file, pb_seq, comment)
+        PB.write_fasta(fasta_file, pb_seq, comment)
     # write phi and psi angles
     if not (isinstance(phipsi_file, _NullContext) or phipsi_file is None):
-        PB.write_phipsi_entry(phipsi_file, dihedrals, comment)
+        PB.write_phipsi(phipsi_file, dihedrals, comment)
     # write PBs in flat file
     if not (isinstance(flat_file, _NullContext) or flat_file is None):
         print(pb_seq, file=flat_file)

--- a/PBassign.py
+++ b/PBassign.py
@@ -41,31 +41,6 @@ except NameError:
     pass
 
 
-def PB_assign(pb_ref, structure, comment,
-              fasta_file=None, flat_file=None, phipsi_file=None):
-    """
-    Assign Protein Blocks (PB) from phi and psi angles
-
-    `fasta_file`, `flat_file`, and `phipsi_file` should be set to an open file
-    if an entry should be written is the file or to None or an instance of
-    _NullContext if no entry should be written.
-    """
-    dihedrals = structure.get_phi_psi_angles()
-    pb_seq = PB.assign(dihedrals, pb_ref)
-
-    # write PBs in fasta file
-    if not (isinstance(fasta_file, _NullContext) or fasta_file is None):
-        PB.write_fasta_entry(fasta_file, pb_seq, comment)
-    # write phi and psi angles
-    if not (isinstance(phipsi_file, _NullContext) or phipsi_file is None):
-        PB.write_phipsi_entry(phipsi_file, dihedrals, comment)
-    # write PBs in flat file
-    if not (isinstance(flat_file, _NullContext) or flat_file is None):
-        print(pb_seq, file=flat_file)
-
-    print("PBs assigned for {0}".format(comment))
-
-
 def user_inputs():
     """
     Handle the user parameter from the command line

--- a/PBassign.py
+++ b/PBassign.py
@@ -41,17 +41,6 @@ except NameError:
     pass
 
 
-class _NullContext(object):
-    """
-    Dummy context manager that does nothing
-    """
-    def __enter__(self):
-        pass
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        pass
-
-
 def PB_assign(pb_ref, structure, comment,
               fasta_file=None, flat_file=None, phipsi_file=None):
     """

--- a/PBassign.py
+++ b/PBassign.py
@@ -66,10 +66,10 @@ def PB_assign(pb_ref, structure, comment,
 
     # write PBs in fasta file
     if not (isinstance(fasta_file, _NullContext) or fasta_file is None):
-        PB.write_fasta(fasta_file, pb_seq, comment)
+        PB.write_fasta_entry(fasta_file, pb_seq, comment)
     # write phi and psi angles
     if not (isinstance(phipsi_file, _NullContext) or phipsi_file is None):
-        PB.write_phipsi(phipsi_file, dihedrals, comment)
+        PB.write_phipsi_entry(phipsi_file, dihedrals, comment)
     # write PBs in flat file
     if not (isinstance(flat_file, _NullContext) or flat_file is None):
         print(pb_seq, file=flat_file)

--- a/PBclust.py
+++ b/PBclust.py
@@ -161,7 +161,7 @@ def compare(header_lst, seq_lst, substitution_mat, fname):
         for header, score_lst in PB.compare_to_first_sequence(header_lst, seq_lst,
                                                               substitution_mat_modified):
             seq = "".join([str(s) for s in score_lst])
-            PB.write_fasta(outfile, seq, header)
+            PB.write_fasta_entry(outfile, seq, header)
     print("wrote {0}".format(fname))
 
 

--- a/PBclust.py
+++ b/PBclust.py
@@ -161,7 +161,7 @@ def compare(header_lst, seq_lst, substitution_mat, fname):
         for header, score_lst in PB.compare_to_first_sequence(header_lst, seq_lst,
                                                               substitution_mat_modified):
             seq = "".join([str(s) for s in score_lst])
-            PB.write_fasta_entry(outfile, seq, header)
+            PB.write_fasta(outfile, seq, header)
     print("wrote {0}".format(fname))
 
 

--- a/PBlib.py
+++ b/PBlib.py
@@ -215,42 +215,6 @@ def load_substitution_matrix(name):
     return mat
 
 
-def clean_file(name):
-    """
-    Clean existing file.
-
-    Parameters
-    ----------
-    name : str
-        Name of file to remove.
-    """
-    if os.path.exists(name):
-        os.remove(name)
-
-
-def write_fasta(name, seq, comment):
-    """
-    Format seq and comment to fasta format and write file.
-
-    Parameters
-    ----------
-    name : str
-        Name of file to write.
-    seq : str
-        Sequence to format.
-    comment : str
-        Comment to make header of sequence.
-
-    """
-    fasta_content = ">"+comment+"\n"
-    fasta_content += "\n".join([seq[i:i+FASTA_WIDTH]
-                                for i in range(0, len(seq), FASTA_WIDTH)])
-    fasta_content += "\n"
-    f_out = open(name, "a")
-    f_out.write(fasta_content)
-    f_out.close()
-
-
 def write_fasta_entry(outfile, sequence, comment, width=FASTA_WIDTH):
     """
     Write a fasta entry (header + sequence) in an open file
@@ -372,24 +336,6 @@ def angle_modulo_360(angle):
         return angle
 
 
-def write_phipsi(name, torsion, com):
-    """
-    Save phi and psi angles
-    """
-    f_out = open(name, "a")
-    for res in sorted(torsion):
-        try:
-            phi_str = "%8.2f" % torsion[res]["phi"]
-        except TypeError:
-            phi_str = "    None"
-        try:
-            psi_str = "%8.2f" % torsion[res]["psi"]
-        except TypeError:
-            psi_str = "    None"
-        f_out.write("%s %6d %s %s \n" % (com, res, phi_str, psi_str))
-    f_out.close()
-
-
 def write_phipsi_entry(outfile, torsion, comment):
     for res in sorted(torsion):
         try:
@@ -401,15 +347,6 @@ def write_phipsi_entry(outfile, torsion, comment):
         except TypeError:
             psi = "    None"
         print("{} {:6d} {} {} ".format(comment, res, phi, psi), file=outfile)
-
-
-def write_flat(name, seq):
-    """
-    Write flat sequence to file
-    """
-    f_out = open(name, "a")
-    f_out.write(seq + "\n")
-    f_out.close()
 
 
 def count_matrix(pb_seq):

--- a/PBlib.py
+++ b/PBlib.py
@@ -265,7 +265,7 @@ def count_to_transfac(identifier, count_content):
     return transfac_content
 
 
-def assign(dihedrals, pb_ref):
+def assign(dihedrals, pb_ref=REFERENCES):
     """
     Assign Protein Blocks.
 

--- a/PBlib.py
+++ b/PBlib.py
@@ -390,6 +390,19 @@ def write_phipsi(name, torsion, com):
     f_out.close()
 
 
+def write_phipsi_entry(outfile, torsion, comment):
+    for res in sorted(torsion):
+        try:
+            phi = "%8.2f" % torsion[res]["phi"]
+        except TypeError:
+            phi = "    None"
+        try:
+            psi = "%8.2f" % torsion[res]["psi"]
+        except TypeError:
+            psi = "    None"
+        print("{} {:6d} {} {} ".format(comment, res, phi, psi), file=outfile)
+
+
 def write_flat(name, seq):
     """
     Write flat sequence to file

--- a/PBlib.py
+++ b/PBlib.py
@@ -234,6 +234,16 @@ def write_fasta_entry(outfile, sequence, comment, width=FASTA_WIDTH):
     print(textwrap.fill(sequence, width=width), file=outfile)
 
 
+def write_fasta(outfile, sequences, comments):
+    for sequence, comment in zip(sequences, comments):
+        write_fasta_entry(outfile, sequence, comment)
+
+
+def write_flat(outfile, sequences):
+    for sequence in sequences:
+        print(sequence, file=outfile)
+
+
 def count_to_transfac(identifier, count_content):
     """
     Convert a table of PB frequencies into transfac format
@@ -347,6 +357,11 @@ def write_phipsi_entry(outfile, torsion, comment):
         except TypeError:
             psi = "    None"
         print("{} {:6d} {} {} ".format(comment, res, phi, psi), file=outfile)
+
+
+def write_phipsi(outfile, torsions, comments):
+    for torsion, comment in zip(torsions, comments):
+        write_phipsi_entry(outfile, torsion, comment)
 
 
 def count_matrix(pb_seq):

--- a/PBlib.py
+++ b/PBlib.py
@@ -215,7 +215,7 @@ def load_substitution_matrix(name):
     return mat
 
 
-def write_fasta(outfile, sequence, comment, width=FASTA_WIDTH):
+def write_fasta_entry(outfile, sequence, comment, width=FASTA_WIDTH):
     """
     Write a fasta entry (header + sequence) in an open file
 
@@ -336,7 +336,7 @@ def angle_modulo_360(angle):
         return angle
 
 
-def write_phipsi(outfile, torsion, comment):
+def write_phipsi_entry(outfile, torsion, comment):
     for res in sorted(torsion):
         try:
             phi = "%8.2f" % torsion[res]["phi"]

--- a/PBlib.py
+++ b/PBlib.py
@@ -215,7 +215,7 @@ def load_substitution_matrix(name):
     return mat
 
 
-def write_fasta_entry(outfile, sequence, comment, width=FASTA_WIDTH):
+def write_fasta(outfile, sequence, comment, width=FASTA_WIDTH):
     """
     Write a fasta entry (header + sequence) in an open file
 
@@ -336,7 +336,7 @@ def angle_modulo_360(angle):
         return angle
 
 
-def write_phipsi_entry(outfile, torsion, comment):
+def write_phipsi(outfile, torsion, comment):
     for res in sorted(torsion):
         try:
             phi = "%8.2f" % torsion[res]["phi"]

--- a/test_regression.py
+++ b/test_regression.py
@@ -262,16 +262,19 @@ class TestPBAssign(TemplateTestCase):
         PBassign should fail as MDanalysis is not available.
         """
         name = 'barstar_md_traj'
-        out_run_dir = path.join(OUTDIR, str(uuid1()))
+        out_run_dir = self._temp_directory
         output_fname = name + '.PB.fasta'
         call_list = ['./PBassign.py',
                      '-x', os.path.join(REFDIR, name + '.xtc'),
                      '-g', os.path.join(REFDIR, name + '.gro'),
                      '-o', os.path.join(out_run_dir, name)]
-        os.mkdir(out_run_dir)
-        status = subprocess.call(call_list,
-                                 stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE)
+        exe = subprocess.Popen(call_list,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+        out, err = exe.communicate()
+        status = exe.wait()
+        print(out.decode('utf-8'))
+        print(err.decode('utf-8'))
         if IS_MDANALYSIS:
             # MDanalysis is available, PBassign should run and produce the
             # correct output
@@ -281,7 +284,7 @@ class TestPBAssign(TemplateTestCase):
         else:
             # MDanalysis is not available, PBassign should fail
             assert status != 0, 'PBassign shoud not have exited with a 0 code'
-        shutil.rmtree(out_run_dir)
+
 
     @_failure_test
     def test_missing_output(self):


### PR DESCRIPTION
In PR #46, I moved the assignment logic from `PBassign.py` to `PBlib.py`. Here, I slightly refactor `PBassign.py` so there is as little code outside of functions as possible. This makes it possible to import `PBassign` without border effect.

This PR also factorize the iteration over chains in two functions: `PDBlib.chains_from_files` and `PDBlib.chains_from_trajectory`. These functions are generators that yield chains either from a list of files or from a trajectory. The PR also get rid of some writing functions: `PBlib.write_fasta` is now replaced by `PBlib.write_fasta_entry`, `PBlib.write_phipsi` is now replaced by `PBlib.write_phipsi_entry`, `PBlib.write_flat` is replaced by just `print`, and `PBlib.clean_file` is just discarded as it is not useful anymore. See commit messages to more details.

The PR also do some cleaning.