### PR TITLE
Travis fails because MDAnalysis is not compatible with Python3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 install:
     - pip install --upgrade pip
     - pip install -r dev_requirements.txt
-    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install mdanalysis; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install "mdanalysis>=0.11"; fi
 
 # command to run tests
 script:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,2 @@
 nose
 coverage
-MDAnalysis>=0.11


### PR DESCRIPTION
The PR #69 make travis builds failed on Python 3.X
The better solution is to remove MDAnalysis from the dev_requirements but indicate the version supported in travis