### PR TITLE
Allows to choose the file format of weblogos in PBstat

### DIFF
--- a/PBstat.py
+++ b/PBstat.py
@@ -177,6 +177,11 @@ parser.add_argument("--neq", action="store_true", default=False, dest="neq",
 parser.add_argument("--logo", action=CommandAction, command="weblogo --help", dest="logo",
     cmd_help="(See https://github.com/pierrepo/PBxplore/blob/master/doc/installation.md)",
     help="generate logo representation of PBs frequency along protein sequence")
+parser.add_argument("--logo-format", action='store', type=str,
+                    dest='logo_format', default='pdf',
+                    choices=['pdf', 'png', 'jpeg', 'eps'],
+                    help=('Weblogo file format. This option is only relevent '
+                          'the --logo option is used'))
 parser.add_argument("--residue-min", action="store", type=int,
     dest="residue_min", help="defines lower bound of residue frame")
 parser.add_argument("--residue-max", action="store", type=int,
@@ -404,14 +409,15 @@ if options.logo:
 
     # define output file name
     #-------------------------------------------------------------------------------
-    logo_file_name = options.o + ".PB.logo.pdf"
+    logo_file_name = options.o + ".PB.logo." + options.logo_format
     if options.residue_min or options.residue_max:
-        logo_file_name = options.o + ".PB.logo.%i-%i.pdf" % (residue_min, residue_max)
+        logo_file_name = "{}.PB.logo.{}-{}.{}".format(
+            options.o, residue_min, residue_max, options.logo_format)
 
     # call weblogo
     #-------------------------------------------------------------------------------
     command = """weblogo \
---format pdf \
+--format %s \
 --errorbars NO \
 --fineprint "" \
 --title %s \
@@ -426,8 +432,8 @@ if options.logo:
 -o %s \
 --lower %i \
 --upper %i 
-    """ % (options.f.replace(".PB.count", ""), logo_file_name, 
-    residue_min, residue_max)
+    """ % (options.logo_format, options.f.replace(".PB.count", ""),
+           logo_file_name, residue_min, residue_max)
 
     proc = subprocess.Popen(command, shell = True,
     stdout = subprocess.PIPE, stderr = subprocess.PIPE, stdin = subprocess.PIPE)

--- a/PBstat.py
+++ b/PBstat.py
@@ -177,11 +177,10 @@ parser.add_argument("--neq", action="store_true", default=False, dest="neq",
 parser.add_argument("--logo", action=CommandAction, command="weblogo --help", dest="logo",
     cmd_help="(See https://github.com/pierrepo/PBxplore/blob/master/doc/installation.md)",
     help="generate logo representation of PBs frequency along protein sequence")
-parser.add_argument("--logo-format", action='store', type=str,
-                    dest='logo_format', default='pdf',
-                    choices=['pdf', 'png', 'jpeg', 'eps'],
-                    help=('Weblogo file format. This option is only relevent '
-                          'the --logo option is used'))
+parser.add_argument("--image-format", action='store', type=str,
+                    dest='image_format', default='png',
+                    choices=['pdf', 'png', 'jpeg'],
+                    help='File format for all image output.')
 parser.add_argument("--residue-min", action="store", type=int,
     dest="residue_min", help="defines lower bound of residue frame")
 parser.add_argument("--residue-max", action="store", type=int,
@@ -277,10 +276,11 @@ freq = freq / float(sequence_number)
 if options.mapdist:
 
     # define output file name
-    map_file_name = options.o + ".PB.map.png"
+    map_file_name = options.o + ".PB.map." + options.image_format
     if options.residue_min or options.residue_max:
-        map_file_name = "{}.PB.map.{}-{}.png".format(
-                        options.o, residue_min, residue_max)
+        map_file_name = "{}.PB.map.{}-{}.{}".format(
+                        options.o, residue_min, residue_max,
+                        options.image_format)
 
     # define ticks for x-axis
     x_step = 5
@@ -366,7 +366,7 @@ if options.neq:
     
     # draw Neq
     #-------------------------------------------------------------------------------
-    neq_fig_name = neq_file_name + '.png'
+    neq_fig_name = neq_file_name + '.' + options.image_format
     fig = plt.figure(figsize=(2.0*math.log(len(residues)), 5))
     ax = fig.add_subplot(1, 1, 1)
     ax.set_ylim([0, round(max(neq_array[:, 1]), 0)+1])
@@ -409,10 +409,10 @@ if options.logo:
 
     # define output file name
     #-------------------------------------------------------------------------------
-    logo_file_name = options.o + ".PB.logo." + options.logo_format
+    logo_file_name = options.o + ".PB.logo." + options.image_format
     if options.residue_min or options.residue_max:
         logo_file_name = "{}.PB.logo.{}-{}.{}".format(
-            options.o, residue_min, residue_max, options.logo_format)
+            options.o, residue_min, residue_max, options.image_format)
 
     # call weblogo
     #-------------------------------------------------------------------------------
@@ -432,7 +432,7 @@ if options.logo:
 -o %s \
 --lower %i \
 --upper %i 
-    """ % (options.logo_format, options.f.replace(".PB.count", ""),
+    """ % (options.image_format, options.f.replace(".PB.count", ""),
            logo_file_name, residue_min, residue_max)
 
     proc = subprocess.Popen(command, shell = True,

--- a/PBstat.py
+++ b/PBstat.py
@@ -179,7 +179,7 @@ parser.add_argument("--logo", action=CommandAction, command="weblogo --help", de
     help="generate logo representation of PBs frequency along protein sequence")
 parser.add_argument("--image-format", action='store', type=str,
                     dest='image_format', default='png',
-                    choices=['pdf', 'png', 'jpeg'],
+                    choices=['pdf', 'png', 'jpeg', 'jpg'],
                     help='File format for all image output.')
 parser.add_argument("--residue-min", action="store", type=int,
     dest="residue_min", help="defines lower bound of residue frame")
@@ -416,6 +416,11 @@ if options.logo:
 
     # call weblogo
     #-------------------------------------------------------------------------------
+    # If the output file format is 'jpeg', then the --format argument of
+    # weblogo should be 'jpeg' even if the user said 'jpg'.
+    logo_format = options.image_format
+    if logo_format == 'jpg':
+        logo_format = 'jpeg'
     command = """weblogo \
 --format %s \
 --errorbars NO \
@@ -432,7 +437,7 @@ if options.logo:
 -o %s \
 --lower %i \
 --upper %i 
-    """ % (options.image_format, options.f.replace(".PB.count", ""),
+    """ % (logo_format, options.f.replace(".PB.count", ""),
            logo_file_name, residue_min, residue_max)
 
     proc = subprocess.Popen(command, shell = True,

--- a/run_demo2.sh
+++ b/run_demo2.sh
@@ -93,6 +93,12 @@ pause
 ../PBstat.py -f psi_md_traj_all.PB.count -o psi_md_traj --map --neq --logo || echo 'The command failed, is weblogo installed?'
 
 echo  -e "\n"
+echo "Change the file format of the weblogo"
+echo "../PBstat.py -f psi_md_traj.PB.count -o psi_md_traj --logo --logo-format png"
+pause
+../PBstat.py -f psi_md_traj_all.PB.count -o psi_md_traj --logo --logo-format png || echo 'The command failed, is weblogo installed?'
+
+echo  -e "\n"
 echo "Define a residue frame (--residue-min and --residue-max options)"
 echo "../PBstat.py -f psi_md_traj.PB.count -o psi_md_traj --map --neq --logo --residue-min 10 --residue-max 30"
 pause

--- a/run_demo2.sh
+++ b/run_demo2.sh
@@ -93,10 +93,10 @@ pause
 ../PBstat.py -f psi_md_traj_all.PB.count -o psi_md_traj --map --neq --logo || echo 'The command failed, is weblogo installed?'
 
 echo  -e "\n"
-echo "Change the file format of the weblogo"
-echo "../PBstat.py -f psi_md_traj.PB.count -o psi_md_traj --logo --logo-format png"
+echo "Change the file format of the images"
+echo "../PBstat.py -f psi_md_traj.PB.count -o psi_md_traj --map --neq --logo --image-format pdf"
 pause
-../PBstat.py -f psi_md_traj_all.PB.count -o psi_md_traj --logo --logo-format png || echo 'The command failed, is weblogo installed?'
+../PBstat.py -f psi_md_traj_all.PB.count -o psi_md_traj --map --neq --logo --image-format pdf || echo 'The command failed, is weblogo installed?'
 
 echo  -e "\n"
 echo "Define a residue frame (--residue-min and --residue-max options)"

--- a/test_regression.py
+++ b/test_regression.py
@@ -580,6 +580,12 @@ class TestPBstat(TemplateTestCase):
                                        output='output',
                                        logo=True, image_format='jpeg')
 
+    def test_weblogo_logo_jpg(self):
+        self._run_program_and_validate(reference='count_multi123',
+                                       input_file='count_multi123.PB.count',
+                                       output='output',
+                                       logo=True, image_format='jpg')
+
     @_failure_test
     def test_weblogo_logo_invalid_format(self):
         self._run_program_and_validate(reference='count_multi123',

--- a/test_regression.py
+++ b/test_regression.py
@@ -460,7 +460,7 @@ class TestPBclust(TemplateTestCase):
 
 class TestPBstat(TemplateTestCase):
     def _build_command_line(self, input_file, output, mapdist=False, neq=False,
-                            logo=False, logo_format=None,
+                            logo=False, image_format=None,
                             residue_min=None, residue_max=None):
         input_full_path = os.path.join(REFDIR, input_file)
         output_full_path = os.path.join(self._temp_directory, output)
@@ -471,8 +471,8 @@ class TestPBstat(TemplateTestCase):
             command += ['--neq']
         if logo:
             command += ['--logo']
-        if logo_format is not None:
-            command += ['--logo-format', logo_format]
+        if image_format is not None:
+            command += ['--image-format', image_format]
         if residue_min is not None:
             command += ['--residue-min', str(residue_min)]
         if residue_max is not None:
@@ -481,7 +481,7 @@ class TestPBstat(TemplateTestCase):
         return command
 
     def _validate_output(self, reference, input_file, output, mapdist=False,
-                         neq=False, logo=False, logo_format=None,
+                         neq=False, logo=False, image_format=None,
                          residue_min=None, residue_max=None, **kwargs):
 
         suffix_residue = ''
@@ -489,19 +489,17 @@ class TestPBstat(TemplateTestCase):
             suffix_residue = ".{}-{}".format(residue_min, residue_max)
 
         suffix_args = ''
-        extension = ''
+        extension = '.png'
         if neq:
             suffix_args = '.Neq'
-            extension = '.png'
         if mapdist:
             suffix_args = '.map'
-            extension = '.png'
         if logo:
             suffix_args = '.logo'
-            if logo_format is None:
-                extension = '.pdf'
-            else:
-                extension = '.' + logo_format
+        if image_format is None:
+            extension = '.png'
+        else:
+            extension = '.' + image_format
 
         reference_full_path = os.path.join(REFDIR, reference + '.PB'
                                            + suffix_args + suffix_residue)
@@ -533,11 +531,23 @@ class TestPBstat(TemplateTestCase):
                                        neq=True,
                                        residue_min=10, residue_max=30)
 
+    def test_neq_pdf(self):
+        self._run_program_and_validate(reference='count_multi123',
+                                       input_file='count_multi123.PB.count',
+                                       output='output',
+                                       neq=True, image_format='pdf')
+
     def test_mapdist(self):
         self._run_program_and_validate(reference='count_multi123',
                                        input_file='count_multi123.PB.count',
                                        output='output',
                                        mapdist=True)
+
+    def test_mapdist_pdf(self):
+        self._run_program_and_validate(reference='count_multi123',
+                                       input_file='count_multi123.PB.count',
+                                       output='output',
+                                       mapdist=True, image_format='pdf')
 
     def test_mapdist_with_range_residues(self):
         self._run_program_and_validate(reference='count_multi123',
@@ -556,32 +566,26 @@ class TestPBstat(TemplateTestCase):
         self._run_program_and_validate(reference='count_multi123',
                                        input_file='count_multi123.PB.count',
                                        output='output',
-                                       logo=True, logo_format='pdf')
+                                       logo=True, image_format='pdf')
 
     def test_weblogo_logo_png(self):
         self._run_program_and_validate(reference='count_multi123',
                                        input_file='count_multi123.PB.count',
                                        output='output',
-                                       logo=True, logo_format='png')
+                                       logo=True, image_format='png')
 
     def test_weblogo_logo_jpeg(self):
         self._run_program_and_validate(reference='count_multi123',
                                        input_file='count_multi123.PB.count',
                                        output='output',
-                                       logo=True, logo_format='jpeg')
-
-    def test_weblogo_logo_eps(self):
-        self._run_program_and_validate(reference='count_multi123',
-                                       input_file='count_multi123.PB.count',
-                                       output='output',
-                                       logo=True, logo_format='eps')
+                                       logo=True, image_format='jpeg')
 
     @_failure_test
-    def test_weblogo_logo_invalif_format(self):
+    def test_weblogo_logo_invalid_format(self):
         self._run_program_and_validate(reference='count_multi123',
                                        input_file='count_multi123.PB.count',
                                        output='output',
-                                       logo=True, logo_format='invalid')
+                                       logo=True, image_format='invalid')
 
 
     def test_weblogo_with_range_residues(self):

--- a/test_regression.py
+++ b/test_regression.py
@@ -460,7 +460,8 @@ class TestPBclust(TemplateTestCase):
 
 class TestPBstat(TemplateTestCase):
     def _build_command_line(self, input_file, output, mapdist=False, neq=False,
-                            logo=False, residue_min=None, residue_max=None):
+                            logo=False, logo_format=None,
+                            residue_min=None, residue_max=None):
         input_full_path = os.path.join(REFDIR, input_file)
         output_full_path = os.path.join(self._temp_directory, output)
         command = ['./PBstat.py', '-f', input_full_path, '-o', output_full_path]
@@ -470,6 +471,8 @@ class TestPBstat(TemplateTestCase):
             command += ['--neq']
         if logo:
             command += ['--logo']
+        if logo_format is not None:
+            command += ['--logo-format', logo_format]
         if residue_min is not None:
             command += ['--residue-min', str(residue_min)]
         if residue_max is not None:
@@ -477,8 +480,9 @@ class TestPBstat(TemplateTestCase):
 
         return command
 
-    def _validate_output(self, reference, input_file, output, mapdist=False, neq=False,
-                         logo=False, residue_min=None, residue_max=None, **kwargs):
+    def _validate_output(self, reference, input_file, output, mapdist=False,
+                         neq=False, logo=False, logo_format=None,
+                         residue_min=None, residue_max=None, **kwargs):
 
         suffix_residue = ''
         if residue_min or residue_max:
@@ -494,7 +498,10 @@ class TestPBstat(TemplateTestCase):
             extension = '.png'
         if logo:
             suffix_args = '.logo'
-            extension = '.pdf'
+            if logo_format is None:
+                extension = '.pdf'
+            else:
+                extension = '.' + logo_format
 
         reference_full_path = os.path.join(REFDIR, reference + '.PB'
                                            + suffix_args + suffix_residue)
@@ -544,6 +551,38 @@ class TestPBstat(TemplateTestCase):
                                        input_file='count_multi123.PB.count',
                                        output='output',
                                        logo=True)
+
+    def test_weblogo_logo_pdf(self):
+        self._run_program_and_validate(reference='count_multi123',
+                                       input_file='count_multi123.PB.count',
+                                       output='output',
+                                       logo=True, logo_format='pdf')
+
+    def test_weblogo_logo_png(self):
+        self._run_program_and_validate(reference='count_multi123',
+                                       input_file='count_multi123.PB.count',
+                                       output='output',
+                                       logo=True, logo_format='png')
+
+    def test_weblogo_logo_jpeg(self):
+        self._run_program_and_validate(reference='count_multi123',
+                                       input_file='count_multi123.PB.count',
+                                       output='output',
+                                       logo=True, logo_format='jpeg')
+
+    def test_weblogo_logo_eps(self):
+        self._run_program_and_validate(reference='count_multi123',
+                                       input_file='count_multi123.PB.count',
+                                       output='output',
+                                       logo=True, logo_format='eps')
+
+    @_failure_test
+    def test_weblogo_logo_invalif_format(self):
+        self._run_program_and_validate(reference='count_multi123',
+                                       input_file='count_multi123.PB.count',
+                                       output='output',
+                                       logo=True, logo_format='invalid')
+
 
     def test_weblogo_with_range_residues(self):
         self._run_program_and_validate(reference='count_multi123',


### PR DESCRIPTION
As stated in #73, PBstat only produces weblogos in PDF format. Yet, weblogo can produce logos in a much larger variety of formats.

This PR adds the `--logo-format` option to PBstat. This option allows to chosse the file format for weblogos. The PR also adapt demo2 to reflect the change, and add extra tests to the regression test suite.

Fix #73