### PR TITLE
Handle optional dependencies.

### DIFF
--- a/pbxplore/__init__.py
+++ b/pbxplore/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from .structure import chains_from_files, chains_from_trajectory
+from .structure.loader import *
 from .assign import assign
 from . import PB
 from . import io

--- a/pbxplore/analysis/__init__.py
+++ b/pbxplore/analysis/__init__.py
@@ -6,4 +6,4 @@ from .compare import compare
 from .count import count_matrix, read_occurence_file
 from .neq import compute_neq
 from .utils import substitution_score, compute_freq_matrix, compute_score_by_position
-from .visualization import generate_weblogo, plot_map, plot_neq
+from .visualization import *

--- a/pbxplore/analysis/visualization.py
+++ b/pbxplore/analysis/visualization.py
@@ -9,17 +9,27 @@ import math
 
 # Third-party modules
 import numpy
-import matplotlib
-import matplotlib.pyplot as plt
+
+# Conditional imports
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+except ImportError:
+    IS_MATPLOTLIB = False
+else:
+    IS_MATPLOTLIB = True
+
+try:
+    import weblogolib
+except ImportError:
+    IS_WEBLOGO = False
+else:
+    IS_WEBLOGO = True
 
 # Local modules
 from .. import PB
 from . import utils
 
-try:
-    import weblogolib
-except ImportError:
-    pass
 
 # Python2/Python3 compatibility
 # The range function in python 3 behaves as the range function in python 2
@@ -30,6 +40,13 @@ try:
     range = xrange
 except NameError:
     pass
+
+# Create the __all__ keyword according to the conditional imports
+__all__ = []
+if IS_MATPLOTLIB:
+    __all__ += ['plot_neq', 'plot_map']
+if IS_WEBLOGO:
+    __all__ += ['generate_weblogo']
 
 
 def plot_neq(fname, neq_array, residue_min=1, residue_max=None):

--- a/pbxplore/structure/__init__.py
+++ b/pbxplore/structure/__init__.py
@@ -2,4 +2,4 @@
 # -*- coding: utf-8 -*-
 
 from .PDB import PDB_EXTENSIONS, PDBx_EXTENSIONS
-from .loader import chains_from_files, chains_from_trajectory
+from .loader import *

--- a/pbxplore/structure/loader.py
+++ b/pbxplore/structure/loader.py
@@ -7,11 +7,19 @@ from __future__ import absolute_import
 from .structure import Chain, Atom
 from .PDB import PDB
 
-
+# Conditional import
 try:
     import MDAnalysis
 except ImportError:
-    pass
+    IS_MDANALYSIS = False
+else:
+    IS_MDANALYSIS = True
+
+
+# Create the __all__ keyword according to the conditional import
+__all__ = ['chains_from_files']
+if IS_MDANALYSIS:
+    __all__ += ['chains_from_trajectory']
 
 
 def chains_from_files(path_list):


### PR DESCRIPTION
Currently, if matplotlib is not present, the import of `pbxplore` will fail. On other hand, if weblogo or MDAnalysis is not present, the functions which use them are still present in the API and will cause errors if they are used.

This PR aims to solve this issue by using conditional imports and by  manipulating  the `__all__` keyword. This keyword contains the public 'objects' of that module which will be exposed from a `from module import *`. By populate it regarding the presence/absence of the conditional imports, only the right functions will be exposed to the API. This is done silently.

For example, if `matplotlib` is not present, `plot_neq()` and `plot_map()` will not be accessible/visible through `pbxplore.analysis.` 

Overall, the API will reflect the presence/absence of the optional dependencies.