### PR TITLE
Expose  `_write_fasta_entry` and `_write_phi_psi_entry` to the API

### DIFF
--- a/pbxplore/analysis/compare.py
+++ b/pbxplore/analysis/compare.py
@@ -89,5 +89,5 @@ def compare(header_lst, seq_lst, substitution_mat, fname):
         for header, score_lst in compare_to_first_sequence(header_lst, seq_lst,
                                                            substitution_mat_modified):
             seq = "".join([str(s) for s in score_lst])
-            fasta._write_fasta_entry(outfile, seq, header)
+            fasta.write_fasta_entry(outfile, seq, header)
     print("wrote {0}".format(fname))

--- a/pbxplore/io/__init__.py
+++ b/pbxplore/io/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from .fasta import read_fasta, read_several_fasta, write_fasta
-from .write import write_phipsi, write_flat, write_count_matrix, write_neq
+from .fasta import read_fasta, read_several_fasta, write_fasta, write_fasta_entry
+from .write import write_phipsi, write_phipsi_entry, write_flat, write_count_matrix, write_neq

--- a/pbxplore/io/fasta.py
+++ b/pbxplore/io/fasta.py
@@ -88,7 +88,7 @@ def read_several_fasta(input_files):
     return pb_name, pb_seq
 
 
-def _write_fasta_entry(outfile, sequence, comment, width=FASTA_WIDTH):
+def write_fasta_entry(outfile, sequence, comment, width=FASTA_WIDTH):
     """
     Write a fasta entry (header + sequence) in an open file
 
@@ -121,4 +121,4 @@ def write_fasta(outfile, sequences, comments):
         List of sequences (str)
     """
     for sequence, comment in zip(sequences, comments):
-        _write_fasta_entry(outfile, sequence, comment)
+        write_fasta_entry(outfile, sequence, comment)

--- a/pbxplore/io/write.py
+++ b/pbxplore/io/write.py
@@ -11,7 +11,7 @@ from .. import PB
 from ..analysis import utils
 
 
-def _write_phipsi_entry(outfile, torsion, comment):
+def write_phipsi_entry(outfile, torsion, comment):
     for res in sorted(torsion):
         try:
             phi = "%8.2f" % torsion[res]["phi"]
@@ -26,7 +26,7 @@ def _write_phipsi_entry(outfile, torsion, comment):
 
 def write_phipsi(outfile, torsions, comments):
     for torsion, comment in zip(torsions, comments):
-        _write_phipsi_entry(outfile, torsion, comment)
+        write_phipsi_entry(outfile, torsion, comment)
 
 
 def write_flat(outfile, sequences):


### PR DESCRIPTION
Fix issue #85 

Rename `_write_fasta_entry` and `_write_phi_psi_entry` into
`write_fasta_entry` and `write_phi_psi_entry` respectively in order them
to be exposed to the API