### PR TITLE
Have Travis build the doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,32 @@ python:
   - "3.4"
   - "3.5"
 
+# Travis build the doc in a separate job, because building the doc is a
+# rater long process. To separate the job, we use a test matrix that
+# would run tests and build the doc for each version of python. Because
+# the doc depends on MDAnalysis that is not compatible with python 3, the doc
+# is actually built for python 2.7 only.
+env:
+  - SETUP=test
+  - SETUP=doc
+
+matrix:
+    exclude:
+        - env: SETUP=doc
+          python: "3.3"
+        - env: SETUP=doc
+          python: "3.4"
+        - env: SETUP=doc
+          python: "3.5"
+
+
 # command to install dependencies
 addons:
     apt:
         packages:
             - r-base
+            - ghc
+            - cabal-install
 
 before_install:
     # Tricks to avoid matplotlib error about X11:
@@ -20,20 +41,34 @@ before_install:
     # http://docs.travis-ci.com/user/gui-and-headless-browsers/#Starting-a-Web-Server
     - "export DISPLAY=:99.0"
     - "sh -e /etc/init.d/xvfb start"
+    # Pandoc, as installed using the cabal program, must be in the PATH
+    - export PATH=$PATH:~/.cabal/bin
+
+# Installing pandoc and matplotlib are long processes. Using a cache allows
+# to fasten the tests by reducing drastically the install time.
+cache:
+    directories:
+        # Cache for pandoc install
+        - $HOME/.cabal
+        # Cache for pip, mostly to speed up matplotlib install
+        - $HOME/.cache/pip
 
 install:
     - pip install --upgrade pip
-    - pip install -r dev_requirements.txt
-    - pip install matplotlib
-    - pip install weblogo
-    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install "mdanalysis>=0.11"; fi
+    - pip install -r dev_requirements.txt --cache-dir $HOME/.cache/pip
+    - pip install matplotlib weblogo --cache-dir $HOME/.cache/pip
+    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install "mdanalysis>=0.11" --cache-dir $HOME/.cache/pip; fi
     - pip install -e .
+    - if [[ $SETUP == 'doc' ]]; then pip install -r doc_requirements.txt --cache-dir $HOME/.cache/pip; fi
+    - if [[ $SETUP == 'doc' ]]; then ./doc-api/source/install_pandoc.sh; fi
+
 
 # command to run tests
 script:
-    - nosetests -v pbxplore
-    - yes | ./run_demo1_assignation.sh
-    - yes | ./run_demo2_statistics.sh
-    - yes | ./run_demo2_clusters.sh
+    - if [[ $SETUP == 'test' ]]; then nosetests -v pbxplore; fi
+    - if [[ $SETUP == 'test' ]]; then yes | ./run_demo1_assignation.sh; fi
+    - if [[ $SETUP == 'test' ]]; then yes | ./run_demo2_statistics.sh; fi
+    - if [[ $SETUP == 'test' ]]; then yes | ./run_demo2_clusters.sh; fi
+    - if [[ $SETUP == 'doc' ]]; then cd doc-api; sphinx-build -W -b html source build/html; fi
 
 #after_success:

--- a/doc-api/source/_static/empty
+++ b/doc-api/source/_static/empty
@@ -1,0 +1,1 @@
+This file allows to have its directory in the git repository.

--- a/doc-api/source/build.sh
+++ b/doc-api/source/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 STATIC_NB_DIR=../build/html/notebooks/
 
 if [[ -n $READTHEDOCS ]]
@@ -14,6 +16,8 @@ fi
 
 mkdir -p $STATIC_NB_DIR
 
+pandoc --version
+
 pip install MDAnalysis
 
 # Prepare the notebooks
@@ -26,7 +30,7 @@ do
     # titles <https://github.com/ipython/ipython/issues/8674>.
     # Therefore, we do the conversion in two steps.
     jupyter-nbconvert --to markdown --execute $notebook --output ${name}.md \
-        --ExecutePreprocessor.timeout=120 \
+        --ExecutePreprocessor.timeout=180 \
         --ExecutePreprocessor.allow_errors=True
     # Because of the 'implicit_figures' extension, pandoc uses the alt text
     # of images as figure caption. Yet, IPython sets the alt text as 'png'
@@ -37,7 +41,9 @@ do
     # The filter also fix the image path because the origin directory for the
     # relative path is not the same between where pandoc runs and where
     # ipython runs.
-    pandoc --from markdown-implicit_figures --filter ./pandoc_fix_img.py -i ${name}.md -o ${name}_.rst
+    pandoc --from markdown-implicit_figures \
+           --filter ./pandoc_fix_img.py \
+           -i ${name}.md -o ${name}_.rst
 
     # Clean and adapt the rst file to have better rendering by sphinx
     cat >> header.txt << EOF

--- a/doc-api/source/install_pandoc.sh
+++ b/doc-api/source/install_pandoc.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Install the last version of pandoc on travis-CI if it is
+# not already available in the cache
+if [[ ! -f $HOME/.cabal/bin/pandoc ]]
+then
+    cabal update
+    cabal install pandoc
+else
+    echo "Get pandoc from the cache"
+fi


### PR DESCRIPTION
Some changes can break the doc or the way it is built. Having Travis
build the doc could allow to detect these changes and to fix them before
merging them.

Travis CI relies on an old version of Ubuntu (12.04) that only provides
an old version of pandoc (1.9). This version of pandoc does not allow to
build the doc. Therefore, we must install a more recent version of
pandoc in Travis. As this install takes about 20 minutes, I set up a
cache. See Travis doc on cache:
<http://docs.travis-ci.com/user/caching/#Arbitrary-directories>

As a cache was set up, I extended it to pip. This is mostly useful for
the install of matplotlib that got speed up from several minutes to
about 4 seconds.

The first Travis run after this commit will be long (more than 20
minutes), but the subsequent run should be faster than what they were
previous to it. A python 3 test job is speed up from about 6 minutes to
about 4 minutes to to the faster install.

As for now, the doc is only built for python 2.7. Indeed, the doc
requires MDAnalysis that is not compatible with python 3. To avoid to
increase further the duration discrepancy between test runs for python 2
and python 3, the doc is built on a separate process. This is done using
build matrix with two different environment: test, and doc. See travis
doc for more details:
<http://docs.travis-ci.com/user/customizing-the-build/>.

Note that the version of pandoc we install in Travis is more recent than
the one used by Read the doc. This version discrepancy is to take into
account! If a change introduces the use of a feature not available in
the Read the docs version of pandoc, the Read the doc failure will not
be predicted by Travis.

Travis is planning a move to Ubuntu 14.04. This upgrade should allow us
to streamline the install of pandoc, as a recent enough version of
pandoc will be available through APT. It should also fix the version
discrepancy between Travis and Read the doc.