### PR TITLE
Specify the version number of pandoc for Travis build

### DIFF
--- a/doc-api/source/install_pandoc.sh
+++ b/doc-api/source/install_pandoc.sh
@@ -5,7 +5,7 @@
 if [[ ! -f $HOME/.cabal/bin/pandoc ]]
 then
     cabal update
-    cabal install pandoc
+    cabal install pandoc-1.15.1.1
 else
     echo "Get pandoc from the cache"
 fi


### PR DESCRIPTION
This PR  fix the issue #108

Recently, the travis build for documentation have failed during the installation of pandoc through cabal.
It seems that the version of pandoc installed through cabal is now 1.15.2.1. This induce a conflict when resolving dependencies (see [travis log](https://travis-ci.org/pierrepo/PBxplore/jobs/94493725)).

One way to solve this is to install a previous version of pandoc, which worked before: 1.15.1.1
