### PR TITLE
Fix performance issues when dealing with large xtc trajectories

### DIFF
--- a/pbxplore/assignment.py
+++ b/pbxplore/assignment.py
@@ -10,6 +10,8 @@ Protrein Block assignation --- :mod:`pbxplore.assignment`
 
 from __future__ import print_function, absolute_import
 
+# Standard module
+import operator
 
 # Third-party module
 import numpy
@@ -75,20 +77,12 @@ def assign(dihedrals, pb_ref=PB.REFERENCES):
             pb_seq += "Z"
             continue
 
-        # convert to array
-        angles = numpy.array(angles)
-
         # compare to reference PB angles
         rmsda_lst = {}
         for block in pb_ref:
-            diff = pb_ref[block] - angles
-            diff2 = _angle_modulo_360_vect(diff)
-            rmsda = numpy.sum(diff2**2)
+            diff = list(map(operator.sub, pb_ref[block], angles))
+            #get the RMSD of the difference
+            rmsda = sum([_angle_modulo_360(d)**2 for d in diff])
             rmsda_lst[rmsda] = block
         pb_seq += rmsda_lst[min(rmsda_lst)]
     return pb_seq
-
-
-# vertorize function
-_angle_modulo_360_vect = numpy.vectorize(_angle_modulo_360)
-_angle_modulo_360_vect.__doc__ = _angle_modulo_360.__doc__

--- a/pbxplore/structure/loader.py
+++ b/pbxplore/structure/loader.py
@@ -38,9 +38,9 @@ def chains_from_files(path_list):
 def chains_from_trajectory(trajectory, topology):
     comment = ""
     universe = MDAnalysis.Universe(topology, trajectory)
+    selection = universe.select_atoms("backbone")
     for ts in universe.trajectory:
         structure = Chain()
-        selection = universe.select_atoms("backbone")
         for atm in selection:
             atom = Atom()
             atom.read_from_xtc(atm)

--- a/pbxplore/structure/structure.py
+++ b/pbxplore/structure/structure.py
@@ -5,6 +5,7 @@ from __future__ import print_function, absolute_import
 
 # Standard module
 import math
+import operator
 
 # Third-party modules
 import numpy
@@ -316,27 +317,31 @@ def get_dihedral(atomA, atomB, atomC, atomD):
     -36.8942888266
     """
 
-    # convert lists to Numpy objects
-    A = numpy.array(atomA)
-    B = numpy.array(atomB)
-    C = numpy.array(atomC)
-    D = numpy.array(atomD)
-
     # vectors
-    AB = B - A
-    BC = C - B
-    CD = D - C
+    AB = list(map(operator.sub, atomB, atomA))
+    BC = list(map(operator.sub, atomC, atomB))
+    CD = list(map(operator.sub, atomD, atomC))
 
     # normal vectors
-    n1 = numpy.cross(AB, BC)
-    n2 = numpy.cross(BC, CD)
+    n1 = []
+    n1.append(((AB[1] * BC[2]) - (AB[2] * BC[1])))
+    n1.append(((AB[2] * BC[0]) - (AB[0] * BC[2])))
+    n1.append(((AB[0] * BC[1]) - (AB[1] * BC[0])))
+    n2 = []
+    n2.append(((BC[1] * CD[2]) - (BC[2] * CD[1])))
+    n2.append(((BC[2] * CD[0]) - (BC[0] * CD[2])))
+    n2.append(((BC[0] * CD[1]) - (BC[1] * CD[0])))
+
+    n1 = numpy.array(n1)
+    n2 = numpy.array(n2)
+
 
     # normalize normal vectors
-    n1 /= numpy.linalg.norm(n1)
-    n2 /= numpy.linalg.norm(n2)
+    n1 /= numpy.sqrt(n1.dot(n1))
+    n2 /= numpy.sqrt(n2.dot(n2))
 
     # angle between normals
-    cosine = numpy.sum(n1*n2) / (numpy.linalg.norm(n1) * numpy.linalg.norm(n2))
+    cosine = n1.dot(n2)
     try:
         torsion = math.acos(cosine)
     except:

--- a/pbxplore/test/test_functions.py
+++ b/pbxplore/test/test_functions.py
@@ -160,7 +160,10 @@ class TestChainClass(unittest.TestCase):
             at.read_from_PDB(line)
             ch.add_atom(at)
 
-        self.assertAlmostEqual(ch.get_phi_psi_angles(), results)
+        phi_psi = ch.get_phi_psi_angles()
+        for resid, angles in results.items():
+            self.assertAlmostEqual(angles["phi"], phi_psi[resid]["phi"])
+            self.assertAlmostEqual(angles["psi"], phi_psi[resid]["psi"])
 
 
 class TestPBlib(unittest.TestCase):


### PR DESCRIPTION
At the lab, we noticed the PB assignment  (with `PBassign`) took a very long time for large xtc trajectories (several Gb).
After some benchmarks, `PBassign` took ~0.4-0.45s to process one frame. This is a very long time. For example, a 25k frames xtc will took approximatively 3h to be processed.

This PR aims to significantly decrease the process time per frame. With this version, I was able to achieve ~0.08-0.10s/frame, almost a 5-fold gain.

The main solution was to get rid of several numpy calls. Indeed, numpy functions can induce a big overhead when dealing with small arrays like ours (for recall, we dealing mainly with 3-items arrays).
I realized that built-in functions (like map(), sum(), comprehension list) are way more fast than their numpy fellows. (Note: the cast of list() with map() is because py2 returns a list and py3 returns a iterator).
Sometimes, some numpy functions are faster than others. Here, it's faster to do a `numpy.sqrt(n1.dot(n1))` than a `numpy.linalg.norm(n1)` but a built-in version will be slower.

Eventually, I optimize the MDAnalysis parsing by creating only one selection. It was pointless to create a selection at every frame since a selection is a view on the structure not on the time.

The main bottleneck now is on these 2 lines:
- https://github.com/HubLot/PBxplore/blob/perf_pbassign/pbxplore/structure/loader.py#L46
- https://github.com/HubLot/PBxplore/blob/perf_pbassign/pbxplore/assignment.py#L85

I think the first one can be optimize if we rethink a little bit how we parse xtc.

I attached 2 files (`statsline_before.txt` and `statsline_after.txt`) which are the results of [line_profiler ](https://github.com/rkern/line_profiler)  before and after the optimization.

[statsline_before.txt](https://github.com/pierrepo/PBxplore/files/189341/statsline_before.txt)
[statsline_after.txt](https://github.com/pierrepo/PBxplore/files/189340/statsline_after.txt)

