### PR TITLE
`pbxplore.test()` doesn't work outside PBxplore folder

### DIFF
--- a/pbxplore/__init__.py
+++ b/pbxplore/__init__.py
@@ -47,6 +47,6 @@ def test():
 
     # run nose
     try:
-        return nose.main(argv=argv)
+        return nose.main(defaultTest=argv)
     except SystemExit as e:
         return e.code


### PR DESCRIPTION
Fix issue #129 
The correct argument for `nose.main()` is not `argv` but `defaultTest`. Cause by default, `defaultTest` is set to '.'.
That's why the `pbxplore.test()`  works inside the PBxplore folder package and didn't work outside