### PR TITLE
[WIP] Release Procedure

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,17 +1,18 @@
-Dev
+**Dev**
 - add some unit tests
 - add a function test() within the root path of PBxplore
 - add a Release file
+- Use of bumpversion to sync version across files
 
-1.3.1
+**1.3.1**
 - remove pbxplore import from setup.py and add version number
 
-1.3
+**1.3**
 - remove --flat and --phipsi from PBassign (and related functions in the api)
 - improve documentation to produce results similar to what --flat and --phipsi options used to produced
 - many performance improvements in the assignment of PBs
 
-1.2
+**1.2**
 - PBxplore is installable via pypi
 - api documentation
 - PBXplore is installable with setup.py

--- a/devtools/RELEASE.md
+++ b/devtools/RELEASE.md
@@ -2,27 +2,39 @@
 
 #### Update version number
 
+We use the tool [bumpversion](https://github.com/peritus/bumpversion) to synchronize the version number
+across different files:
 
-#### Publish Documentation
-
+    bumpversion --verbose --config-file devtools/bumpversion.cfg  patch
+    git push origin
+    git push origin --tags
 
 #### Publish on Pypi
 
 
+
+#### Publish Documentation
+
+
 #### Publish on Conda
+
 
 1. Build the package (inside `conda` directory)
 
-    conda build --python 2.7 --python 3.3 --python 3.4 --python 3.5 -c bioconda -c mdanalysis pbxplore
+    `conda build --python 2.7 --python 3.3 --python 3.4 --python 3.5 -c bioconda -c mdanalysis pbxplore`
+
 
 2. The path of the created archive will be given at the end of the process
 
+
 3. Convert it for all plateforms (where `X.X.X` is the pbxplore version and `YY` is the Python version)
 
-    conda convert --platform all /path/to/archive/pbxplore-X.X.X-pyYY_0.tar.bz2
+    `conda convert --platform all /path/to/archive/pbxplore-X.X.X-pyYY_0.tar.bz2`
+
 
 4. Upload it to anaconda
 
-    anaconda upload /path/to/archive/pbxplore-X.X.X-pyYY_0.tar.bz2
+    `anaconda upload /path/to/archive/pbxplore-X.X.X-pyYY_0.tar.bz2`
+
 
 This has to be done for each package created.

--- a/devtools/bumpversion.cfg
+++ b/devtools/bumpversion.cfg
@@ -1,0 +1,20 @@
+[bumpversion]
+commit = True
+tag = True
+current_version = 1.3.1
+# The version 0.1.2 has 3 parts. Major is for 0, minor is for 1 and patch is for 2
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
+serialize =
+	{major}.{minor}.{patch}
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:pbxplore/__init__.py]
+
+[bumpversion:file:devtools/conda/pbxplore/meta.yaml]
+
+[bumpversion:file:CHANGELOG]
+search = **Dev**
+replace = **Dev**
+	**{new_version}**
+


### PR DESCRIPTION
~~Please merge the PR #131 first before this one (I'll rebase it once it's merged).~~ **done**

Hi,

First step to create a procedure to release a PBxplore version (`RELEASE` file).
I used [bumpversion](https://github.com/peritus/bumpversion) tool to synchronize the version number across the different files.

TODO:
- [ ] Fill the pypi procedure
- [ ] Fill the readthedocs procedure
