### PR TITLE
Handle production of NaN during angle calculations.

### DIFF
--- a/pbxplore/scripts/PBassign.py
+++ b/pbxplore/scripts/PBassign.py
@@ -112,17 +112,24 @@ def pbassign_cli():
     all_comments = []
     all_sequences = []
     for comment, chain in chains:
-        dihedrals = chain.get_phi_psi_angles()
-        sequence = pbx.assign(dihedrals)
-        all_comments.append(comment)
-        all_sequences.append(sequence)
+        try:
+            dihedrals = chain.get_phi_psi_angles()
+            sequence = pbx.assign(dihedrals)
+            all_comments.append(comment)
+            all_sequences.append(sequence)
+        except FloatingPointError:
+            print("The computation of angles produced NaN. This typically means there are issues"
+                  " with some residues coordinates. Check your input file ({0})".format(comment),
+                  file=sys.stderr)
 
-    fasta_name = options.o + ".PB.fasta"
-    with open(fasta_name, 'w') as outfile:
-        pbx.io.write_fasta(outfile, all_sequences, all_comments)
+    if all_comments:
+        fasta_name = options.o + ".PB.fasta"
+        with open(fasta_name, 'w') as outfile:
+            pbx.io.write_fasta(outfile, all_sequences, all_comments)
 
-    print("wrote {0}".format(fasta_name))
-
+        print("wrote {0}".format(fasta_name))
+    else:
+        print("No output file was written")
 
 if __name__ == '__main__':
     pbassign_cli()


### PR DESCRIPTION
Numpy can produce NaN during dihedral calculations (in `get_dihedral` function). This can occurs when we try to normalize the vectors ("Divide by Zero"). It usually means there is issues with some residus coordinates (for example, 2 residus superposed).
The problem is the dictionary of phi/psi angle is still returned and the assignation is still made despite the NaN in the angle. This produces incorrect assignations which could be difficult to spot on a analysis of many PDBs.

This PR fix those issues by :

- Transform the `RuntimeWarning` produced by numpy  in a proper `FloatingPointException` exception (through `numpy.errstate(invalid='raise')`).
This change is made in `get_phi_psi_angles()` function before the main loop on the residus. Hence, it's only done once and **do not change the speed of the calculations** (it's even a little bit faster but not sure it's significative).
- Re-raise the exception in `get_phi_psi_angles()` function in order to keep the traceback and provide a proper exiting tool for the function (helpful for module users).
- Catch the exception in `PBassign`, warn the user about the issue and don't write the assignation.

