### PR TITLE
Fix encoding issue with weblogo file (#152)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 **Dev**
+- Fix encoding issue with weblogo file (#152)
 - Move print statement of PDBs read from PDB class to the loader module
 - add a property in PDB class to get the number of chains
 - add a progress bar during PB assignment of a trajectory (#150)

--- a/pbxplore/analysis/visualization.py
+++ b/pbxplore/analysis/visualization.py
@@ -253,5 +253,5 @@ def generate_weblogo(fname, count_mat, idx_first_residue=1, residue_min=1, resid
     image = formatter(data, logo)
 
     # Write it
-    with open(fname, "w") as f:
-        print(image, file=f)
+    with open(fname, "wb") as f:
+        f.write(image)


### PR DESCRIPTION
Weblogo functions returns binary data for the logo which have to be writen to a file. 

Since Python 2 and Python 3 handles differently binary data,  I had to re-write a little bit how we write the weblogo data into a  file.
Mainly, we have to open the output file as a binary and use the `write` function of the descriptor.

