### PR TITLE
Travis python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 # Travis build the doc in a separate job, because building the doc is a
 # rater long process. To separate the job, we use a test matrix that

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,13 @@ env:
   - SETUP=test
   - SETUP=doc
 
-matrix:
-    exclude:
-        - env: SETUP=doc
-          python: "3.4"
-        - env: SETUP=doc
-          python: "3.5"
+# Keep it commented
+# matrix:
+#     exclude:
+#         - env: SETUP=doc
+#           python: "3.4"
+#         - env: SETUP=doc
+#           python: "3.5"
 
 
 # command to install dependencies
@@ -56,6 +57,7 @@ install:
     - pip install "mdanalysis>=0.11" --cache-dir $HOME/.cache/pip
     - pip install -e .
     - if [[ $SETUP == 'doc' ]]; then pip install -r doc_requirements.txt --cache-dir $HOME/.cache/pip; fi
+    - if [[ $SETUP == 'doc' ]] && [[ $TRAVIS_PYTHON_VERSION != 2.7 ]]; then python2 -m pip install ipykernel; python2 -m ipykernel install --user; fi
 
 
 # command to run tests

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 - fix visualization functions when the index of first residue is different of 1 (#148)
 - update documentation
 - update example files for documentation (and related doc)
+- update Travis with Python 3.6
 
 **1.3.3**
 - update RELEASE doc (PyPI url)


### PR DESCRIPTION
Update travis to build doc also for Python 3.x

For Python 3, we need python2 kernel for jupyter notebooks to convert the notebooks into html. Hence, the new `pip` line.