### PR TITLE
Mordernize the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,7 @@ matrix:
 addons:
     apt:
         packages:
-            - ghc
-            - cabal-install
+            - ghostscript
 
 before_install:
     # Tricks to avoid matplotlib error about X11:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,13 +56,13 @@ install:
     - pip install -r dev_requirements.txt --cache-dir $HOME/.cache/pip
     - pip install matplotlib weblogo --cache-dir $HOME/.cache/pip
     - pip install "mdanalysis>=0.11" --cache-dir $HOME/.cache/pip
-    - pip install -e .
+    - pip install .
     - if [[ $SETUP == 'doc' ]]; then pip install -r doc_requirements.txt --cache-dir $HOME/.cache/pip; fi
 
 
 # command to run tests
 script:
-    - if [[ $SETUP == 'test' ]]; then nosetests -v pbxplore/tests; fi
+    - if [[ $SETUP == 'test' ]]; then pytest -v pbxplore/tests; fi
     - if [[ $SETUP == 'doc' ]]; then cd doc; sphinx-build -W -b html source build/html; fi
 
 #after_success:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-nose
+pytest
 coverage
 sphinx >= 1.3.1
 sphinxcontrib-napoleon

--- a/devtools/conda/pbxplore/meta.yaml
+++ b/devtools/conda/pbxplore/meta.yaml
@@ -46,7 +46,7 @@ test:
 
   requires:
     - coverage
-    - nose
+    - pytest
 
 about:
   home: https://github.com/pierrepo/PBxplore

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -82,7 +82,7 @@ Testing PBxplore
 ----------------
 
 `PBxplore` comes with unit tests and regression tests. It requires the package
-`nose <https://nose.readthedocs.io/en/latest/>`_. You can run the tests within Python:
+`pytest <https://docs.pytest.org>`_. You can run the tests within Python:
 
 .. code-block:: python
 
@@ -128,15 +128,15 @@ You can also run unit tests and regression tests:
 
 .. code-block:: bash
 
-    $ pip install nose
-    $ nosetests -v pbxplore/tests
+    $ pip install pytest
+    $ pytest -v pbxplore/tests
 
 or
 
 .. code-block:: bash
 
-    $ pip install nose
-    $ python setup.py nosetests
+    $ pip install pytest
+    $ python setup.py test
 
 
 .. [#] J. D. Hunter.

--- a/pbxplore/__init__.py
+++ b/pbxplore/__init__.py
@@ -29,9 +29,9 @@ def test():
     import os
 
     try:
-        import nose
+        import pytest
     except ImportError:
-        raise ImportError("Nose have to be installed for tests")
+        raise ImportError("Pytest have to be installed for tests")
 
     # find the directory where the test package lives
     from . import tests
@@ -40,10 +40,10 @@ def test():
 
     #Get informations about system
     tests.system_info()
-    print("nose version {}".format(nose.__version__))
+    print("pytest version {}".format(pytest.__version__))
 
-    # run nose
+    # run pytest
     try:
-        return nose.main(defaultTest=argv)
+        return pytest.main(argv)
     except SystemExit as e:
         return e.code

--- a/pbxplore/tests/test_functions.py
+++ b/pbxplore/tests/test_functions.py
@@ -12,10 +12,11 @@ Tests functions from different programs.
 # =============================================================================
 # Modules
 # =============================================================================
-import unittest
 import collections
 import os
 import numpy
+
+import pytest
 
 import pbxplore as pbx
 from pbxplore.structure import structure
@@ -28,60 +29,65 @@ here = os.path.abspath(os.path.dirname(__file__))
 # =============================================================================
 # Classes for tests
 # =============================================================================
-class TestStructurelib(unittest.TestCase):
+
+
+Result = collections.namedtuple('Result', ['A', 'B', 'C', 'D', 'torsion'])
+
+
+class TestStructurelib(object):
     """
     Tests for Structurelib
     """
 
-    def test_get_dihedral(self):
+    @pytest.mark.parametrize('result',
+        (Result((-7.28, -9.262, 5.077),
+                (-7.526, -10.643, 5.529),
+                (-6.221, -11.438, 5.555),
+                (-6.289, -12.685, 5.931),
+                -179.663656153),
+         Result((-1.373, -8.817, -4.389),
+                (-1.203, -8.335, -5.792),
+                (-1.891, -6.977, -5.927),
+                (-1.918, -6.429, -7.107),
+                -176.048770127),
+         Result((-0.533, -8.42, -3.47  ),
+                (-1.373, -8.817, -4.389),
+                (-1.203, -8.335, -5.792),
+                (-1.891, -6.977, -5.927),
+                -84.8356057692),
+         Result((-1.918, -6.429, -7.107),
+                (-2.609, -5.125, -7.305),
+                (-4.108, -5.392, -7.331),
+                (-4.469, -6.494, -7.911),
+                -36.8942888266),
+         Result((-11.285, 6.472, -7.44 ),
+                (-12.62, 5.829, -7.425 ),
+                (-13.585, 6.626, -6.544),
+                (-13.098, 7.621, -5.858),
+                -6.58786169376),
+         Result((-11.284, -0.971, -2.679),
+                (-12.65, -0.794, -3.226),
+                (-13.665, -1.664, -2.479),
+                (-13.262, -2.363, -1.452),
+                3.91626706556),
+         Result((-2.004, -10.892, -2.611),
+                (-1.87, -9.835, -1.853),
+                (-0.726, -8.877, -2.011),
+                (-0.533, -8.42, -3.47),
+                50.065196067),
+         Result((11.174, -6.725, 0.458),
+                (10.732, -7.258, -0.86),
+                (9.27, -6.869, -1.096),
+                (8.741, -7.185, -2.245),
+                175.872397707))
+     )
+    def test_get_dihedral(self, result):
         """
         Test for get_dihedral()
         """
-        Result = collections.namedtuple('Result', ['A', 'B', 'C', 'D', 'torsion'])
-        results = (Result((-7.28, -9.262, 5.077),
-                          (-7.526, -10.643, 5.529),
-                          (-6.221, -11.438, 5.555),
-                          (-6.289, -12.685, 5.931),
-                          -179.663656153),
-                   Result((-1.373, -8.817, -4.389),
-                          (-1.203, -8.335, -5.792),
-                          (-1.891, -6.977, -5.927),
-                          (-1.918, -6.429, -7.107),
-                          -176.048770127),
-                   Result((-0.533, -8.42, -3.47  ),
-                          (-1.373, -8.817, -4.389),
-                          (-1.203, -8.335, -5.792),
-                          (-1.891, -6.977, -5.927),
-                          -84.8356057692),
-                   Result((-1.918, -6.429, -7.107),
-                          (-2.609, -5.125, -7.305),
-                          (-4.108, -5.392, -7.331),
-                          (-4.469, -6.494, -7.911),
-                          -36.8942888266),
-                   Result((-11.285, 6.472, -7.44 ),
-                          (-12.62, 5.829, -7.425 ),
-                          (-13.585, 6.626, -6.544),
-                          (-13.098, 7.621, -5.858),
-                          -6.58786169376),
-                   Result((-11.284, -0.971, -2.679),
-                          (-12.65, -0.794, -3.226),
-                          (-13.665, -1.664, -2.479),
-                          (-13.262, -2.363, -1.452),
-                          3.91626706556),
-                   Result((-2.004, -10.892, -2.611),
-                          (-1.87, -9.835, -1.853),
-                          (-0.726, -8.877, -2.011),
-                          (-0.533, -8.42, -3.47),
-                          50.065196067),
-                   Result((11.174, -6.725, 0.458),
-                          (10.732, -7.258, -0.86),
-                          (9.27, -6.869, -1.096),
-                          (8.741, -7.185, -2.245),
-                          175.872397707))
-
-        for res in results:
-            torsion = structure.get_dihedral(res.A, res.B, res.C, res.D)
-            self.assertAlmostEqual(torsion, res.torsion)
+        torsion = structure.get_dihedral(result.A, result.B,
+                                         result.C, result.D)
+        assert torsion == pytest.approx(result.torsion)
 
     def test_loader_PDB(self):
         """
@@ -92,8 +98,8 @@ class TestStructurelib(unittest.TestCase):
 
         ref_comment = "{0} | model 1 | chain A".format(filename)
         ref_chain = "Chain A / model 1: 2372 atoms"
-        self.assertEqual(ref_comment, comment)
-        self.assertEqual(ref_chain, format(chain))
+        assert ref_comment == comment
+        assert ref_chain == format(chain)
 
     def test_loader_xtc(self):
         """
@@ -106,69 +112,72 @@ class TestStructurelib(unittest.TestCase):
         comment, chain = chains[0]
         ref_comment = "{0} | frame 0".format(traj)
         ref_chain = "Chain  / model : 355 atoms"
-        self.assertEqual(ref_comment, comment)
-        self.assertEqual(ref_chain, format(chain))
+        assert ref_comment == comment
+        assert ref_chain == format(chain)
 
         comment, chain = chains[-1]
         ref_comment = "{0} | frame 9".format(traj)
-        self.assertEqual(ref_comment, comment)
-        self.assertEqual(ref_chain, format(chain))
+        assert ref_comment == comment
+        assert ref_chain == format(chain)
 
 
-class TestAtomClass(unittest.TestCase):
+class TestAtomClass(object):
     """
     Tests for the Atom class in PDBlib
     """
 
     PDBx_fields = ['group_PDB', 'id', 'type_symbol', 'label_atom_id',
-              'label_alt_id', 'label_comp_id', 'label_asym_id', 'label_entity_id',
-              'label_seq_id', 'pdbx_PDB_ins_code', 'Cartn_x', 'Cartn_y', 'Cartn_z',
-              'occupancy', 'B_iso_or_equiv', 'Cartn_x_esd', 'Cartn_y_esd',
-              'Cartn_z_esd', 'occupancy_esd', 'B_iso_or_equiv_esd',
-              'pdbx_formal_charge', 'auth_seq_id', 'auth_comp_id', 'auth_asym_id',
-              'auth_atom_id', 'pdbx_PDB_model_num']
+                   'label_alt_id', 'label_comp_id', 'label_asym_id',
+                   'label_entity_id', 'label_seq_id', 'pdbx_PDB_ins_code',
+                   'Cartn_x', 'Cartn_y', 'Cartn_z', 'occupancy',
+                   'B_iso_or_equiv', 'Cartn_x_esd', 'Cartn_y_esd',
+                   'Cartn_z_esd', 'occupancy_esd', 'B_iso_or_equiv_esd',
+                   'pdbx_formal_charge', 'auth_seq_id', 'auth_comp_id',
+                   'auth_asym_id', 'auth_atom_id', 'pdbx_PDB_model_num']
 
-    def test_read_from_PDB(self):
+    @pytest.mark.parametrize(
+        'line, expected',
+        (("ATOM    512  N   GLU A  32      -1.870  -9.835  -1.853  1.00  0.56           N  ", [-1.87, -9.835, -1.853]),
+         ("ATOM   1424  CA  SER A  89       7.604  11.308   1.435  1.00  0.62           C  ", [7.604, 11.308, 1.435]),
+         ("ATOM   1167  CG2 VAL B  50       9.294  44.541  -4.830  1.00 27.62           C  ", [9.294, 44.541, -4.83]))
+    )
+    def test_read_from_PDB(self, line, expected):
         """
         Tests for read_from_PDB()
         """
-        a = structure.Atom.read_from_PDB("ATOM    512  N   GLU A  32      -1.870  -9.835  -1.853  1.00  0.56           N  ")
-        self.assertAlmostEqual(a.coords, [-1.87, -9.835, -1.853])
-        a = structure.Atom.read_from_PDB("ATOM   1424  CA  SER A  89       7.604  11.308   1.435  1.00  0.62           C  ")
-        self.assertAlmostEqual(a.coords, [7.604, 11.308, 1.435])
-        a = structure.Atom.read_from_PDB("ATOM   1167  CG2 VAL B  50       9.294  44.541  -4.830  1.00 27.62           C  ")
-        self.assertAlmostEqual(a.coords, [9.294, 44.541, -4.83])
+        atom = structure.Atom.read_from_PDB(line)
+        assert atom.coords == pytest.approx(expected)
 
     def test_read_PDB_line_short(self):
         """
         Test when PDB line is too short
         """
-        with self.assertRaises(structure.AtomError):
+        with pytest.raises(structure.AtomError):
             structure.Atom.read_from_PDB("ATOM    512  N   GLU A  32      -1.870  -9.835")
 
-    def test_read_from_PDBx(self):
+    @pytest.mark.parametrize(
+        'line,coordinates',
+        (("ATOM 4769  H HB   . ILE A 1 35  ? -20.422 5.104   -0.207  1.00 0.00 ? ? ? ? ? ? 277 ILE A HB   3", [-20.422, 5.104, -0.207]),
+         ("ATOM 18201 H HG21 . THR A 1 140 ? 11.080  -12.466 -8.977  1.00 0.00 ? ? ? ? ? ? 382 THR A HG21 8", [11.08, -12.466, -8.977]),
+         ("ATOM 23720 H HE2  . HIS A 1 193 ? 13.974  24.297  0.352   1.00 0.00 ? ? ? ? ? ? 435 HIS A HE2  10", [13.974, 24.297, 0.352]))
+    )
+    def test_read_from_PDBx(self, line, coordinates):
         """
         Tests for read_from_PDBx()
         """
-        line = "ATOM 4769  H HB   . ILE A 1 35  ? -20.422 5.104   -0.207  1.00 0.00 ? ? ? ? ? ? 277 ILE A HB   3"
-        a = structure.Atom.read_from_PDBx(line, self.PDBx_fields)
-        self.assertAlmostEqual(a.coords, [-20.422, 5.104, -0.207])
-        line = "ATOM 18201 H HG21 . THR A 1 140 ? 11.080  -12.466 -8.977  1.00 0.00 ? ? ? ? ? ? 382 THR A HG21 8"
-        a = structure.Atom.read_from_PDBx(line, self.PDBx_fields)
-        self.assertAlmostEqual(a.coords, [11.08, -12.466, -8.977])
-        line = "ATOM 23720 H HE2  . HIS A 1 193 ? 13.974  24.297  0.352   1.00 0.00 ? ? ? ? ? ? 435 HIS A HE2  10"
-        a = structure.Atom.read_from_PDBx(line, self.PDBx_fields)
-        self.assertAlmostEqual(a.coords, [13.974, 24.297, 0.352])
+        atom = structure.Atom.read_from_PDBx(line, self.PDBx_fields)
+        assert atom.coords == pytest.approx(coordinates)
 
-    def test_read_PDBx_failed_line(self):
+    @pytest.mark.parametrize(
+        'line',
+        ("ATOM 4769  H HB   . ILE A 1 35  ? -20.422 5.104",
+         "ATOM 4769  H HB   . ILE A 1 XXX  ? -20.422 5.104   -0.207  1.00 0.00 ? ? ? ? ? ? 277 ILE A HB   3",)
+    )
+    def test_read_PDBx_failed_line(self, line):
         """
         Test when PDBx line is not correctly formated
         """
-        line = "ATOM 4769  H HB   . ILE A 1 35  ? -20.422 5.104"
-        with self.assertRaises(structure.AtomError):
-            structure.Atom.read_from_PDBx(line, self.PDBx_fields)
-        line = "ATOM 4769  H HB   . ILE A 1 XXX  ? -20.422 5.104   -0.207  1.00 0.00 ? ? ? ? ? ? 277 ILE A HB   3"
-        with self.assertRaises(structure.AtomError):
+        with pytest.raises(structure.AtomError):
             structure.Atom.read_from_PDBx(line, self.PDBx_fields)
 
     def test_read_from_xtc(self):
@@ -182,28 +191,34 @@ class TestAtomClass(unittest.TestCase):
 
         # First timeframe
         atom = structure.Atom.read_from_xtc(selection[0])
-        self.assertEqual(atom.resid, 1)
-        self.assertEqual(atom.name, "N")
-        [self.assertAlmostEqual(a, b, places=3) for a, b in zip(atom.coords, [21.68, 33.87, 36.18])]
+        assert atom.resid == 1
+        assert atom.name == "N"
+        for a, b in zip(atom.coords, [21.68, 33.87, 36.18]):
+            assert a == pytest.approx(b, abs=1e-3)
         atom = structure.Atom.read_from_xtc(selection[-1])
-        self.assertEqual(atom.resid, 89)
-        self.assertEqual(atom.name, "C")
-        [self.assertAlmostEqual(a, b, places=3) for a, b in zip(atom.coords, [40.14, 38.75, 28.42])]
+        assert atom.resid == 89
+        assert atom.name == "C"
+        for a, b in zip(atom.coords, [40.14, 38.75, 28.42]):
+            assert a == pytest.approx(b, abs=1e-3)
 
         #Last one
         ts = universe.trajectory[-1]
         atom = structure.Atom.read_from_xtc(selection[0])
-        [self.assertAlmostEqual(a, b, places=3) for a, b in zip(atom.coords, [20.63, 38.43, 32.09])]
+        for a, b in zip(atom.coords, [20.63, 38.43, 32.09]):
+            assert a == pytest.approx(b, abs=1e-3)
         atom = structure.Atom.read_from_xtc(selection[-1])
-        [self.assertAlmostEqual(a, b, places=3) for a, b in zip(atom.coords, [39.14, 39.77, 25.60])]
+        for a, b in zip(atom.coords, [39.14, 39.77, 25.60]):
+            assert a == pytest.approx(b, abs=1e-3)
 
 
-class TestChainClass(unittest.TestCase):
+class TestChainClass(object):
     """
     Tests for Chain class in PDBlib
     """
 
-    def setUp(self):
+    @staticmethod
+    @pytest.fixture
+    def chain():
         """
         Run before each test.
 
@@ -214,31 +229,32 @@ class TestChainClass(unittest.TestCase):
                  "ATOM    850  CA  SER B  12      22.385  23.396  -1.637  1.00 21.99           C  ",
                  "ATOM    851  C   SER B  12      21.150  24.066  -0.947  1.00 32.67           C  ",
                  "ATOM    855  N   ILE B  13      20.421  23.341  -0.088  1.00 30.25           N  ")
-        self.ch = structure.Chain()
+        chain = structure.Chain()
         for line in lines:
-            at = structure.Atom.read_from_PDB(line)
-            self.ch.add_atom(at)
+            atom = structure.Atom.read_from_PDB(line)
+            chain.add_atom(atom)
+        return chain
 
-    def test_size(self):
+    def test_size(self, chain):
         """
         Tests for size()
         """
-        self.assertEqual(self.ch.size(), 5)
+        assert chain.size() ==  5
 
-    def test_get_phi_psi_angles(self):
+    @pytest.mark.parametrize(
+        'resid,angles',
+        ((11, {'phi': None, 'psi': None}),
+         (12, {'phi': -139.77684605036447, 'psi': 157.94348570201197}),
+         (13, {'phi': None, 'psi': None}))
+    )
+    def test_get_phi_psi_angles(self, chain, resid, angles):
         """
         Tests for get_phi_psi_angles()
         """
-        results = {11: {'phi': None, 'psi': None},
-                   12: {'phi': -139.77684605036447, 'psi': 157.94348570201197},
-                   13: {'phi': None, 'psi': None}}
+        phi_psi = chain.get_phi_psi_angles()
+        assert angles["phi"] == pytest.approx(phi_psi[resid]["phi"])
 
-        phi_psi = self.ch.get_phi_psi_angles()
-        for resid, angles in results.items():
-            self.assertAlmostEqual(angles["phi"], phi_psi[resid]["phi"])
-            self.assertAlmostEqual(angles["psi"], phi_psi[resid]["psi"])
-
-    def test_set_coordinates(self):
+    def test_set_coordinates(self, chain):
         """
         Tests for coordinates update
         """
@@ -247,94 +263,123 @@ class TestChainClass(unittest.TestCase):
                                   [3.00, 3.00, 3.00],
                                   [4.00, 4.00, 4.00],
                                   [5.00, 5.00, 5.00]])
-        self.ch.set_coordinates(new_coords)
+        chain.set_coordinates(new_coords)
 
-        for atom, ref_coords in zip(self.ch, new_coords):
+        for atom, ref_coords in zip(chain, new_coords):
             numpy.testing.assert_array_almost_equal(atom.coords, ref_coords)
 
         # Wrong shape
         wrong_coords = new_coords[:-1]
-        with self.assertRaises(ValueError):
-            self.ch.set_coordinates(wrong_coords)
+        with pytest.raises(ValueError):
+            chain.set_coordinates(wrong_coords)
 
 
-class TestPDBClass(unittest.TestCase):
+class TestPDBClass(object):
     """
     Tests for PDB class in Structurelib
     """
 
-    def test_read_single_PDB(self):
+    @staticmethod
+    @pytest.fixture
+    def chains_1BTA():
+        filename = os.path.join(here, "test_data/1BTA.pdb")
+        pdb = pbx.structure.PDB.PDB(filename)
+        return list(pdb.get_chains())
+
+    @staticmethod
+    @pytest.fixture
+    def chains_1AY7_pdb():
+        filename = os.path.join(here, "test_data/1AY7.pdb")
+        pdb = pbx.structure.PDB.PDB(filename)
+        return list(pdb.get_chains())
+
+    @staticmethod
+    @pytest.fixture
+    def chains_1AY7_pdbx():
+        filename = os.path.join(here, "test_data/1AY7.cif.gz")
+        pdb = pbx.structure.PDB.PDB(filename)
+        return list(pdb.get_chains())
+
+    @staticmethod
+    @pytest.fixture
+    def chains_2LFU():
+        filename = os.path.join(here, "test_data/2LFU.pdb")
+        pdb = pbx.structure.PDB.PDB(filename)
+        return list(pdb.get_chains())
+
+    @pytest.mark.parametrize(
+        'index,ref',
+        ((0, "ATOM      1    N LYS A   1      -8.655   5.770   8.371  0.00  0.00              "),
+         (-1, "ATOM   1434   HG SER A  89       6.663  12.440   4.229  0.00  0.00              "))
+    )
+    def test_read_single_PDB(self, chains_1BTA, index, ref):
         """
         Tests for single chain in one PDB
         """
-        filename = os.path.join(here, "test_data/1BTA.pdb")
-        pdb = pbx.structure.PDB.PDB(filename)
-        chain = list(pdb.get_chains())[0]
+        chain = chains_1BTA[0]
+        assert chain[index].format() == ref
 
-        ref = "ATOM      1    N LYS A   1      -8.655   5.770   8.371  0.00  0.00              "
-        self.assertEqual(chain[0].format(), ref)
-        ref = "ATOM   1434   HG SER A  89       6.663  12.440   4.229  0.00  0.00              "
-        self.assertEqual(chain[-1].format(), ref)
-
-    def test_read_multiple_PDB(self):
+    @pytest.mark.parametrize(
+        'chain_idx,ref_first,ref_last',
+        ((0,
+          "ATOM      1    N ASP A   1      11.860  13.207  12.724  0.00  0.00              ",
+          "ATOM    751  OXT CYS A  96       9.922  16.291  36.110  0.00  0.00              "),
+         (1,
+          "ATOM    753    N LYS B   1      11.318  46.585   0.493  0.00  0.00              ",
+          "ATOM   1489  OXT SER B  89      13.857  33.192 -16.133  0.00  0.00              "))
+    )
+    def test_read_multiple_PDB(self, chains_1AY7_pdb, chain_idx,
+                               ref_first, ref_last):
         """
-        Tests for multiple chains in one PDB
+        Tests for multiple chains in one file.
+
+        This test is called for both PDB abd PDBx format because the
+        `chains_1AY7` fixture is parametrixed for both extensions.
         """
-        filename = os.path.join(here, "test_data/1AY7.pdb.gz")
-        pdb = pbx.structure.PDB.PDB(filename)
-        chains = list(pdb.get_chains())
+        chain = chains_1AY7_pdb[chain_idx]
+        assert chain[0].format() == ref_first
+        assert chain[-1].format() == ref_last
 
-        chain_A = chains[0]
-        ref = "ATOM      1    N ASP A   1      11.860  13.207  12.724  0.00  0.00              "
-        self.assertEqual(chain_A[0].format(), ref)
-        ref = "ATOM    751  OXT CYS A  96       9.922  16.291  36.110  0.00  0.00              "
-        self.assertEqual(chain_A[-1].format(), ref)
-
-        chain_B = chains[1]
-        ref = "ATOM    753    N LYS B   1      11.318  46.585   0.493  0.00  0.00              "
-        self.assertEqual(chain_B[0].format(), ref)
-        ref = "ATOM   1489  OXT SER B  89      13.857  33.192 -16.133  0.00  0.00              "
-        self.assertEqual(chain_B[-1].format(), ref)
-
-    def test_read_models_PDB(self):
+    def test_read_models_PDB(self, chains_2LFU):
         """
         Tests for multiple models in one PDB
         """
-        filename = os.path.join(here, "test_data/2LFU.pdb")
-        pdb = pbx.structure.PDB.PDB(filename)
-        chains = list(pdb.get_chains())
-
         #3 models of one chain
-        self.assertEqual(len(chains), 3)
+        assert len(chains_2LFU) == 3
 
-        model_3 = chains[2]
+        model_3 = chains_2LFU[2]
         ref = "ATOM      1    N ASN A 276     -21.874   9.349   4.010  0.00  0.00              "
-        self.assertEqual(model_3[0].format(), ref)
-        self.assertEqual(model_3.model, "3")
+        assert model_3[0].format() == ref
+        assert model_3.model == "3"
 
-
-    def test_read_multiple_PDBx(self):
+    # This test could be factorized with `test_read_multiple_PDB` by
+    # parametrizing the `chains_1AY7_*` fixture. Yet, the atom number of the
+    # second chain are shifted by one between the PDB and the PDBx file. This
+    # is due to the TER record counting in the sequence of atom numbers in the
+    # PDB file.
+    @pytest.mark.parametrize(
+        'chain_idx,ref_first,ref_last',
+        ((0,
+          "ATOM      1    N ASP A   1      11.860  13.207  12.724  0.00  0.00              ",
+          "ATOM    751  OXT CYS A  96       9.922  16.291  36.110  0.00  0.00              "),
+         (1,
+          "ATOM    752    N LYS B   1      11.318  46.585   0.493  0.00  0.00              ",
+          "ATOM   1488  OXT SER B  89      13.857  33.192 -16.133  0.00  0.00              "))
+    )
+    def test_read_multiple_PDBx(self, chains_1AY7_pdbx, chain_idx,
+                                ref_first, ref_last):
         """
-        Tests for multiple chains in one PDBx
+        Tests for multiple chains in one file.
+
+        This test is called for both PDB abd PDBx format because the
+        `chains_1AY7` fixture is parametrixed for both extensions.
         """
-        filename = os.path.join(here, "test_data/1AY7.cif.gz")
-        pdb = pbx.structure.PDB.PDB(filename)
-        chains = list(pdb.get_chains())
-
-        chain_A = chains[0]
-        ref = "ATOM      1    N ASP A   1      11.860  13.207  12.724  0.00  0.00              "
-        self.assertEqual(chain_A[0].format(), ref)
-        ref = "ATOM    751  OXT CYS A  96       9.922  16.291  36.110  0.00  0.00              "
-        self.assertEqual(chain_A[-1].format(), ref)
-
-        chain_B = chains[1]
-        ref = "ATOM    752    N LYS B   1      11.318  46.585   0.493  0.00  0.00              "
-        self.assertEqual(chain_B[0].format(), ref)
-        ref = "ATOM   1488  OXT SER B  89      13.857  33.192 -16.133  0.00  0.00              "
-        self.assertEqual(chain_B[-1].format(), ref)
+        chain = chains_1AY7_pdbx[chain_idx]
+        assert chain[0].format() == ref_first
+        assert chain[-1].format() == ref_last
 
 
-class TestIolib(unittest.TestCase):
+class TestIolib(object):
     """
     Tests for Iolib
     """
@@ -343,15 +388,13 @@ class TestIolib(unittest.TestCase):
         """
         Test for parsing mulitple fastas
         """
-        headers, sequences = pbx.io.read_fasta(os.path.join(here, "test_data/1AY7.pdb.PB.fasta"))
-        self.assertEqual(headers, ['test_data/1AY7.pdb | chain A',
-                                   'test_data/1AY7.pdb | chain B'])
-        self.assertEqual(sequences, ['ZZbjadfklmcfklmmmmmmmmnnpaafbfkgo'
-                                     'pacehlnomaccddehjaccdddddehklpnbja'
-                                     'dcdddfbehiacddfegolaccdddfkZZ',
-                                     'ZZcddfklpcbfklmmmmmmmmnopafklgoiakl'
-                                     'mmmmmmmmpacddddddehkllmmmmnnommmmmm'
-                                     'mmmmmmmmnopacddddZZ'])
-
-if __name__ == '__main__':
-    unittest.main()
+        filename = os.path.join(here, "test_data/1AY7.pdb.PB.fasta") 
+        headers, sequences = pbx.io.read_fasta(filename)
+        assert headers == ['test_data/1AY7.pdb | chain A',
+                           'test_data/1AY7.pdb | chain B']
+        assert sequences == ['ZZbjadfklmcfklmmmmmmmmnnpaafbfkgo'
+                             'pacehlnomaccddehjaccdddddehklpnbja'
+                             'dcdddfbehiacddfegolaccdddfkZZ',
+                             'ZZcddfklpcbfklmmmmmmmmnopafklgoiakl'
+                             'mmmmmmmmpacddddddehkllmmmmnnommmmmm'
+                             'mmmmmmmmnopacddddZZ']

--- a/pbxplore/tests/test_regression.py
+++ b/pbxplore/tests/test_regression.py
@@ -15,7 +15,6 @@ test that the output is the expected one based on a previous version.
 # Use print as a function like in python 3
 from __future__ import print_function
 
-import unittest
 from os import path
 from uuid import uuid1
 from functools import wraps
@@ -24,6 +23,7 @@ import subprocess
 import shutil
 import sys
 
+import pytest
 
 import MDAnalysis
 
@@ -41,76 +41,22 @@ here = os.path.abspath(os.path.dirname(__file__))
 # Resources for the tests are stored in the following directory
 REFDIR = os.path.join(here, "test_data/")
 
-# Temporary outputs will be written in this directory
-OUTDIR = "test_tmp/"
 
-
-def _failure_test(method):
-    """
-    Decorate tests that are supposed to fail
-
-    Some tests asses that things that should go wrong actually go wrong. These
-    tests should fail. The _failure_test decorator reverse the assesment test
-    so if the decorated test sucess it is reported as failed.
-
-    This decorator differs to unittest.expectedFailure. The
-    unittest.expectedFailure aims at decorate tests that are supposed to sucess
-    but are known to failed.
-    """
-    @wraps(method)
-    def wrapped(*args, **kwargs):
-        try:
-            method(*args, **kwargs)
-        except AssertionError:
-            pass
-        else:
-            raise AssertionError('Test should have failed.')
-    return wrapped
-
-
-class TemplateTestCase(unittest.TestCase):
+class TemplateTestCase(object):
     """
     Template TestCase class for the other TestCase class to inherit from.
 
     Children class must overload the `_build_command_line` and the
     `_validate_output` methods.
     """
-    def setUp(self):
-        """
-        Run before each test.
-
-        Make sure that the output directory exists. And create a temporary
-        directory to work in.
-        """
-        if not path.isdir(OUTDIR):
-            os.mkdir(OUTDIR)
-        self._temp_directory = os.path.join(OUTDIR, str(uuid1()))
-        os.mkdir(self._temp_directory)
-
-    def tearDown(self):
-        """
-        Run after each test.
-
-        Delete the temporary directory except if the test failed. Note that, on
-        python 3, the temporary directory is always deleted.
-        """
-        if ((sys.version_info[0] == 2 and sys.exc_info() == (None, None, None))
-                or sys.version_info[0] == 3):
-            # On python 2, sys.exc_info() is (None, None, None) only when a
-            # test pass. On python 3, however, there is no difference in
-            # sys.exc_info() between a passing and a failing test. Here, on
-            # python 2, we delete the temporary directory only is the test
-            # passes; on python 3 we always delete the temporary directory.
-            shutil.rmtree(self._temp_directory)
-
-    def _run_program_and_validate(self, reference, **kwargs):
+    def _run_program_and_validate(self, out_run_dir, reference, **kwargs):
         """
         Run the program to test and validate its outputs.
         """
         # Build the command line to run. This relies on the _build_command_line
         # method that is a virtual method, which must be overloaded by the
         # child class.
-        command = self._build_command_line(**kwargs)
+        command = self._build_command_line(str(out_run_dir), **kwargs)
         print(command)
 
         # Run the command.
@@ -126,7 +72,7 @@ class TemplateTestCase(unittest.TestCase):
 
         # Validate the output files. This relies on the _validate_output
         # virtual method.
-        self._validate_output(reference, **kwargs)
+        self._validate_output(str(out_run_dir), reference, **kwargs)
 
     def _build_command_line(self, **kwargs):
         """
@@ -149,15 +95,17 @@ class TestPBAssign(TemplateTestCase):
     """
     Regression tests for PBAssign.py
     """
-    def _run_PBassign(self, pdbid, extension, multiple=None, indir=REFDIR, outdir=OUTDIR):
+    references = ["1BTA", "1AY7", "2LFU", "3ICH"]
+    extensions = [".pdb", ".cif.gz"]
+
+    def _run_PBassign(self, out_run_dir, pdbid, extension,
+                      multiple=None, indir=REFDIR):
         """
         Run a PBxplore program on a PDBID with the given options.
 
         `options` is expected to be a list that will be directly passed to
         subprocess, it must not contain the input or output options.
         """
-        out_run_dir = os.path.join(self._temp_directory, str(uuid1()))
-        os.mkdir(out_run_dir)
         if multiple is None:
             test_input = path.join(REFDIR, pdbid + extension)
             out_basename = path.join(out_run_dir, pdbid)
@@ -177,46 +125,43 @@ class TestPBAssign(TemplateTestCase):
 
         return exe.returncode, out_run_dir
 
-    def _test_PBassign_options(self, basenames, extensions, outfiles,
+    def _test_PBassign_options(self, out_run_dir, basename, extension, outfiles,
                                multiple=None, expected_exit=0):
+        out_run_dir = str(out_run_dir)
         if multiple is not None:
-            basenames = [basenames]
             out_name = multiple
-        for basename in basenames:
-            for extension in extensions:
-                status, out_run_dir = self._run_PBassign(basename, extension, multiple)
-                assert status == expected_exit, \
-                       'PBassign stoped with a {0} exit code'.format(status)
-                assert len(os.listdir(out_run_dir)) == len(outfiles),\
-                        ('PBassign did not produced the right number of files: '
-                         '{0} files produced instead of {1}').format(
-                            len(os.listdir(out_run_dir)), len(outfiles))
-                out_name = basename if multiple is None else multiple
-                for outfile in (template.format(out_name + extension)
-                                for template in outfiles):
-                    test_file = path.join(out_run_dir, outfile)
-                    ref_file = path.join(REFDIR, outfile)
-                    _assert_identical_files(test_file, ref_file)
+        status, out_run_dir = self._run_PBassign(out_run_dir, basename, extension, multiple)
+        assert status == expected_exit, \
+               'PBassign stoped with a {0} exit code'.format(status)
+        assert len(os.listdir(out_run_dir)) == len(outfiles),\
+                ('PBassign did not produced the right number of files: '
+                 '{0} files produced instead of {1}').format(
+                    len(os.listdir(out_run_dir)), len(outfiles))
+        out_name = basename if multiple is None else multiple
+        for outfile in (template.format(out_name + extension)
+                        for template in outfiles):
+            test_file = path.join(out_run_dir, outfile)
+            ref_file = path.join(REFDIR, outfile)
+            _assert_identical_files(test_file, ref_file)
 
-    def test_fasta(self):
+    @pytest.mark.parametrize('reference', references)
+    @pytest.mark.parametrize('extension', extensions)
+    def test_fasta(self, tmpdir, reference, extension):
         """
         Run PBAssign on PDB files, and check the fasta output.
         """
-        references = ["1BTA", "1AY7", "2LFU", "3ICH"]
-        extensions = [".pdb", ".cif.gz"]
-        self._test_PBassign_options(references, extensions,
+        self._test_PBassign_options(tmpdir, reference, extension,
                                     ['{0}.PB.fasta'])
 
-    def test_multiple_inputs(self):
+    @pytest.mark.parametrize('extension', extensions)
+    def test_multiple_inputs(self, tmpdir, extension):
         """
         Run PBassign with multiple inputs.
         """
-        references = ["1BTA", "1AY7", "2LFU", "3ICH"]
-        extensions = [".pdb", ".cif.gz"]
-        self._test_PBassign_options(references, extensions,
+        self._test_PBassign_options(tmpdir, self.references, extension,
                                     ['{0}.PB.fasta'], multiple='all')
 
-    def test_xtc_input(self):
+    def test_xtc_input(self, tmpdir):
         """
         Run PBassign on a trajectory in the XTC format.
 
@@ -224,7 +169,7 @@ class TestPBAssign(TemplateTestCase):
         PBassign should fail as MDanalysis is not available.
         """
         name = 'barstar_md_traj'
-        out_run_dir = self._temp_directory
+        out_run_dir = str(tmpdir)
         output_fname = name + '.PB.fasta'
         call_list = ['PBassign',
                      '-x', os.path.join(REFDIR, name + '.xtc'),
@@ -245,23 +190,23 @@ class TestPBAssign(TemplateTestCase):
                                 os.path.join(out_run_dir, output_fname))
 
 
-    @_failure_test
-    def test_different_outputs(self):
+    @pytest.mark.xfail(strict=True, raises=AssertionError)
+    def test_different_outputs(self, tmpdir):
         """
         Test if the tests properly fail if an output content is different from
         expected.
         """
-        references = ["test_fail"]
-        extensions = [".pdb"]
-        self._test_PBassign_options(references, extensions, ['{0}.PB.fasta'])
+        reference = "test_fail"
+        extension = ".pdb"
+        self._test_PBassign_options(tmpdir, reference, extension, ['{0}.PB.fasta'])
 
 
 class TestPBcount(TemplateTestCase):
     """
     Test running PBcount.
     """
-    def _build_command_line(self, input_files, output, first_residue=None):
-        output_full_path = os.path.join(self._temp_directory, output)
+    def _build_command_line(self, out_run_dir, input_files, output, first_residue=None):
+        output_full_path = os.path.join(out_run_dir, output)
         command = ['PBcount', '-o', output_full_path]
         for input_file in input_files:
             command += ['-f', os.path.join(REFDIR, input_file)]
@@ -269,33 +214,33 @@ class TestPBcount(TemplateTestCase):
             command += ['--first-residue', str(first_residue)]
         return command
 
-    def _validate_output(self, reference, output, **kwargs):
+    def _validate_output(self, out_run_dir, reference, output, **kwargs):
         reference_full_path = os.path.join(REFDIR, reference)
-        output_full_path = os.path.join(self._temp_directory,
+        output_full_path = os.path.join(out_run_dir,
                                         output + '.PB.count')
         _assert_identical_files(output_full_path, reference_full_path)
 
-    def test_single_file_single_model(self):
+    def test_single_file_single_model(self, tmpdir):
         """
         Run PBcount with a single input file that contains a single model.
         """
         input_files = ['count_single1.PB.fasta', ]
         output = 'output'
         reference = 'count_single1.PB.count'
-        self._run_program_and_validate(reference,
+        self._run_program_and_validate(tmpdir, reference,
                                        input_files=input_files, output=output)
 
-    def test_single_file_multiple_models(self):
+    def test_single_file_multiple_models(self, tmpdir):
         """
         Run PBcount with a single input file that contains multiple models.
         """
         input_files = ['count_multi1.PB.fasta', ]
         output = 'output'
         reference = 'count_multi1.PB.count'
-        self._run_program_and_validate(reference,
+        self._run_program_and_validate(tmpdir, reference,
                                        input_files=input_files, output=output)
 
-    def test_multiple_files_single_model(self):
+    def test_multiple_files_single_model(self, tmpdir):
         """
         Run PBcount with multiple input files that contain a single model.
         """
@@ -304,10 +249,10 @@ class TestPBcount(TemplateTestCase):
                        'count_single3.PB.fasta']
         output = 'output'
         reference = 'count_single123.PB.count'
-        self._run_program_and_validate(reference,
+        self._run_program_and_validate(tmpdir, reference,
                                        input_files=input_files, output=output)
 
-    def test_multiple_files_multiple_models(self):
+    def test_multiple_files_multiple_models(self, tmpdir):
         """
         Run PBcount with multiple input files that contain multiple models each.
         """
@@ -316,10 +261,10 @@ class TestPBcount(TemplateTestCase):
                        'count_multi3.PB.fasta']
         output = 'output'
         reference = 'count_multi123.PB.count'
-        self._run_program_and_validate(reference,
+        self._run_program_and_validate(tmpdir, reference,
                                        input_files=input_files, output=output)
 
-    def test_first_residue_positive(self):
+    def test_first_residue_positive(self, tmpdir):
         """
         Test PBcount on with the --first-residue option and a positive value.
         """
@@ -328,11 +273,11 @@ class TestPBcount(TemplateTestCase):
                        'count_multi3.PB.fasta']
         output = 'output'
         reference = 'count_multi123_first20.PB.count'
-        self._run_program_and_validate(reference,
+        self._run_program_and_validate(tmpdir, reference,
                                        input_files=input_files, output=output,
                                        first_residue=20)
 
-    def test_first_residue_negative(self):
+    def test_first_residue_negative(self, tmpdir):
         """
         Test PBcount on with the --first-residue option and a negative value.
         """
@@ -341,18 +286,19 @@ class TestPBcount(TemplateTestCase):
                        'count_multi3.PB.fasta']
         output = 'output'
         reference = 'count_multi123_first-20.PB.count'
-        self._run_program_and_validate(reference,
+        self._run_program_and_validate(tmpdir, reference,
                                        input_files=input_files, output=output,
                                        first_residue=-20)
 
 
 
 class TestPBstat(TemplateTestCase):
-    def _build_command_line(self, input_file, output, mapdist=False, neq=False,
+    def _build_command_line(self, out_run_dir, input_file, output,
+                            mapdist=False, neq=False,
                             logo=False, image_format=None,
                             residue_min=None, residue_max=None):
         input_full_path = os.path.join(REFDIR, input_file)
-        output_full_path = os.path.join(self._temp_directory, output)
+        output_full_path = os.path.join(str(out_run_dir), output)
         command = ['PBstat', '-f', input_full_path, '-o', output_full_path]
         if mapdist:
             command += ['--map']
@@ -369,8 +315,8 @@ class TestPBstat(TemplateTestCase):
 
         return command
 
-    def _validate_output(self, reference, input_file, output, mapdist=False,
-                         neq=False, logo=False, image_format=None,
+    def _validate_output(self, out_run_dir, reference, input_file, output,
+                         mapdist=False, neq=False, logo=False, image_format=None,
                          residue_min=None, residue_max=None, **kwargs):
 
         suffix_residue = ''
@@ -392,7 +338,7 @@ class TestPBstat(TemplateTestCase):
 
         reference_full_path = os.path.join(REFDIR, reference + '.PB'
                                            + suffix_args + suffix_residue)
-        output = os.path.join(self._temp_directory, output)
+        output = os.path.join(str(out_run_dir), output)
         output_full_path = output + '.PB' + suffix_args + suffix_residue
 
         if neq:
@@ -401,102 +347,117 @@ class TestPBstat(TemplateTestCase):
 
         # Assess the creation of the graph file (png or pdf)
         value, msg = _file_validity(output_full_path + extension)
-        self.assertTrue(value, msg=msg)
+        assert value, msg
 
-    def test_neq(self):
-        self._run_program_and_validate(reference='count_multi123',
+    def test_neq(self, tmpdir):
+        self._run_program_and_validate(tmpdir,
+                                       reference='count_multi123',
                                        input_file='count_multi123.PB.count',
                                        output='output',
                                        neq=True)
-        self._run_program_and_validate(reference='count_single123',
+        self._run_program_and_validate(tmpdir,
+                                       reference='count_single123',
                                        input_file='count_single123.PB.count',
                                        output='output',
                                        neq=True)
 
-    def test_neq_with_range_residues(self):
-        self._run_program_and_validate(reference='count_multi123',
+    def test_neq_with_range_residues(self, tmpdir):
+        self._run_program_and_validate(tmpdir,
+                                       reference='count_multi123',
                                        input_file='count_multi123.PB.count',
                                        output='output',
                                        neq=True,
                                        residue_min=10, residue_max=30)
 
-    def test_neq_with_first_residue(self):
-        self._run_program_and_validate(reference='count_multi123_first20',
+    def test_neq_with_first_residue(self, tmpdir):
+        self._run_program_and_validate(tmpdir,
+                                       reference='count_multi123_first20',
                                        input_file='count_multi123_first20.PB.count',
                                        output='output',
                                        neq=True)
 
-    def test_neq_with_first_range_residues(self):
-        self._run_program_and_validate(reference='count_multi123_first20',
+    def test_neq_with_first_range_residues(self, tmpdir):
+        self._run_program_and_validate(tmpdir,
+                                       reference='count_multi123_first20',
                                        input_file='count_multi123_first20.PB.count',
                                        output='output',
                                        neq=True,
                                        residue_min=25, residue_max=35)
 
-    def test_neq_pdf(self):
-        self._run_program_and_validate(reference='count_multi123',
+    def test_neq_pdf(self, tmpdir):
+        self._run_program_and_validate(tmpdir,
+                                       reference='count_multi123',
                                        input_file='count_multi123.PB.count',
                                        output='output',
                                        neq=True, image_format='pdf')
 
-    def test_mapdist(self):
-        self._run_program_and_validate(reference='count_multi123',
+    def test_mapdist(self, tmpdir):
+        self._run_program_and_validate(tmpdir,
+                                       reference='count_multi123',
                                        input_file='count_multi123.PB.count',
                                        output='output',
                                        mapdist=True)
 
-    def test_mapdist_pdf(self):
-        self._run_program_and_validate(reference='count_multi123',
+    def test_mapdist_pdf(self, tmpdir):
+        self._run_program_and_validate(tmpdir,
+                                       reference='count_multi123',
                                        input_file='count_multi123.PB.count',
                                        output='output',
                                        mapdist=True, image_format='pdf')
 
-    def test_mapdist_with_range_residues(self):
-        self._run_program_and_validate(reference='count_multi123',
+    def test_mapdist_with_range_residues(self, tmpdir):
+        self._run_program_and_validate(tmpdir,
+                                       reference='count_multi123',
                                        input_file='count_multi123.PB.count',
                                        output='output',
                                        mapdist=True,
                                        residue_min=10, residue_max=30)
 
-    @unittest.skipUnless(IS_WEBLOGO, "Weblogo is not present")
-    def test_weblogo(self):
-        self._run_program_and_validate(reference='count_multi123',
+    @pytest.mark.skipif(not IS_WEBLOGO, reason="Weblogo is not present")
+    def test_weblogo(self, tmpdir):
+        self._run_program_and_validate(tmpdir,
+                                       reference='count_multi123',
                                        input_file='count_multi123.PB.count',
                                        output='output',
                                        logo=True)
 
-    @unittest.skipUnless(IS_WEBLOGO, "Weblogo is not present")
-    def test_weblogo_logo_pdf(self):
-        self._run_program_and_validate(reference='count_multi123',
+    @pytest.mark.skipif(not IS_WEBLOGO, reason="Weblogo is not present")
+    def test_weblogo_logo_pdf(self, tmpdir):
+        self._run_program_and_validate(tmpdir,
+                                       reference='count_multi123',
                                        input_file='count_multi123.PB.count',
                                        output='output',
                                        logo=True, image_format='pdf')
 
-    @unittest.skipUnless(IS_WEBLOGO, "Weblogo is not present")
-    def test_weblogo_logo_png(self):
-        self._run_program_and_validate(reference='count_multi123',
+    @pytest.mark.skipif(not IS_WEBLOGO, reason="Weblogo is not present")
+    def test_weblogo_logo_png(self, tmpdir):
+        self._run_program_and_validate(tmpdir,
+                                       reference='count_multi123',
                                        input_file='count_multi123.PB.count',
                                        output='output',
                                        logo=True, image_format='png')
 
-    @unittest.skipUnless(IS_WEBLOGO, "Weblogo is not present")
-    def test_weblogo_logo_jpg(self):
-        self._run_program_and_validate(reference='count_multi123',
+    @pytest.mark.skipif(not IS_WEBLOGO, reason="Weblogo is not present")
+    def test_weblogo_logo_jpg(self, tmpdir):
+        self._run_program_and_validate(tmpdir,
+                                       reference='count_multi123',
                                        input_file='count_multi123.PB.count',
                                        output='output',
                                        logo=True, image_format='jpg')
 
-    @unittest.skipUnless(IS_WEBLOGO, "Weblogo is not present")
-    @_failure_test
-    def test_weblogo_logo_invalid_format(self):
-        self._run_program_and_validate(reference='count_multi123',
+    @pytest.mark.skipif(not IS_WEBLOGO, reason="Weblogo is not present")
+    @pytest.mark.xfail(strict=True, raises=AssertionError)
+    def test_weblogo_logo_invalid_format(self, tmpdir):
+        self._run_program_and_validate(tmpdir,
+                                       reference='count_multi123',
                                        input_file='count_multi123.PB.count',
                                        output='output',
                                        logo=True, image_format='invalid')
 
-    @unittest.skipUnless(IS_WEBLOGO, "Weblogo is not present")
-    def test_weblogo_with_range_residues(self):
-        self._run_program_and_validate(reference='count_multi123',
+    @pytest.mark.skipif(not IS_WEBLOGO, reason="Weblogo is not present")
+    def test_weblogo_with_range_residues(self, tmpdir):
+        self._run_program_and_validate(tmpdir,
+                                       reference='count_multi123',
                                        input_file='count_multi123.PB.count',
                                        output='output',
                                        logo=True,

--- a/pbxplore/tests/test_regression.py
+++ b/pbxplore/tests/test_regression.py
@@ -4,18 +4,12 @@
 """
 Regression tests for PBxplore.
 
-This script run the various PBxplore programs with various argument, and makes
-sure the output is the expected one. The aim is to check that the programs are
-not broken during development.
+This test suite run the various PBxplore programs with various argument, and
+makes sure the output is the expected one. The aim is to check that the
+programs are not broken during development.
 
-Be careful this script does not test that the output is right. It just test
-that the output is the expected one based on a previous version.
-
-To run this test suite, you can either run this script without arguments or use
-the nose [1]_ package. The latter option gives a more readable output, as
-stdout is captured, and is displayed only if a test fails.
-
-.. [1] https://nose.readthedocs.org
+Be careful this test suite does not test that the output is right. It just
+test that the output is the expected one based on a previous version.
 """
 
 # Use print as a function like in python 3
@@ -568,7 +562,3 @@ def _assert_identical_files(file_a, file_b, comment_char=">"):
     """
     assert _same_file_content(file_a, file_b), '{0} and {1} are not identical'\
                                                .format(file_a, file_b)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,8 @@
 # Compatible Python 2 and Python 3.
 universal=1
 
-[nosetests]
-verbosity=1
-detailed-errors=1
+[aliases]
+test=pytest
+
+[tool:pytest]
+addopts = --verbose

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,9 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
 
+    setup_requires=['pytest-runner'],
     install_requires=['numpy', 'MDAnalysis>=0.11', 'matplotlib'],
-    tests_require=['nose', 'coverage'],
+    tests_require=['pytest', 'pytest-raises', 'coverage'],
     # List additional groups of dependencies here
     # To install, use
     # $ pip install -e .[analysis]


### PR DESCRIPTION
So far, the tests rely on the Nose framework. Nose provides both a smart test runner, and some utility functions t write the tests. However, Nose is not maintained any more, and therefore is deprecated. Continuing to use Nose is not sustainable.

This pull request port the complete test suite from Nose to the still maintained Pytest. The port is made in two steps:
* in the first step, I made the minimum changes needed to have the tests running on pytest; this includes updating the documentation, the install, and travis
* in a second step, I updated the tests to use the idioms recommended by pytest.

Here is a brief summary of the main pytest idioms:
* **raw assert instead of specialized assert functions:** nose, so as the `unittest` library from the standard library, encourages the use of specialized assert functions. The semantics added in these specialized functions allows more informative error messages compared to raw asserts. Pytest, instead, rewrites the bytecode of each assert call to adapt it to the context.
* **fixtures:** instead of setup and tear down, pytest uses "fixtures". Fixtures are functions that produce a resource. That resource can be attached to a given scope (module, class, function), the scope by default being the function/method. To have access to a resource, a test must have an argument with the same name as the fixture. One benefit of fixtures compared to set up / tear down is an greater flexibility. Indeed, not all the test in a given scope require the same resources; with a setup approach, all common resources are built in the setup even for tests that do not require them all. Fixture are created on demand, only for the tests that require them.
* **tmpdir:** one built-in fixture of pytest is the `tmpdir` fixture. This fixture creates a temporary directory that lives for the duration of a test.
* **parametrized tests:** one last magic of pytest is the ability to "parametrize" tests. These tests have a list of parameters attached to them and will run for each element of that list. This allows to separate the logic of the tests from the data, but also to limit the code of a test to the strict minimum since the all part about looping over multiple set of parameters is moved out of the test, and it allows to have each parameter run separately giving more granularity to the output. This replaces the test generators of nose that we were not using.

There are some additional magic in pytest that I did not described here. See [the website](https://docs.pytest.org) for more.

Finally, a preliminary step was required for the tests to pass. Ghostscript was not available in the latest travis run, likely due to some update. Because of this, all the tests involving weblogo were failing. I added ghostscript to the package to install using apt. I also removed cabal and haskell from the install as they were not needed anymore since pandoc is installed from a deb package. Latter on, it may be worth trying to install pandoc from apt as travis is rolling in a more recent version of ubuntu.