### PR TITLE
Bumb the minimal MDAnalysis version required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
     - pip install --upgrade pip
     - pip install -r dev_requirements.txt --cache-dir $HOME/.cache/pip
     - pip install matplotlib weblogo --cache-dir $HOME/.cache/pip
-    - pip install "mdanalysis>=0.11" --cache-dir $HOME/.cache/pip
+    - pip install "mdanalysis>=0.16" --cache-dir $HOME/.cache/pip
     - pip install .
     - if [[ $SETUP == 'doc' ]]; then pip install -r doc_requirements.txt --cache-dir $HOME/.cache/pip; fi
 

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Requirements
 PBxplore requires:
 
 * Python 2.7 or Python 3.x (>= 3.4)
-* Python modules: `NumPy <http://numpy.scipy.org/>`_, `Matplotlib <http://matplotlib.org/>`_, `MDAnalysis <https://code.google.com/p/mdanalysis/>`_ (version >= 0.11).
+* Python modules: `NumPy <http://numpy.scipy.org/>`_, `Matplotlib <http://matplotlib.org/>`_, `MDAnalysis <https://code.google.com/p/mdanalysis/>`_ (version >= 0.16).
 
 Optionally, PBxplore can use:
 

--- a/devtools/conda/pbxplore/meta.yaml
+++ b/devtools/conda/pbxplore/meta.yaml
@@ -20,14 +20,14 @@ requirements:
     - numpy
     - matplotlib
     - python-weblogo
-    - mdanalysis >=0.11
+    - mdanalysis >=0.16
 
   run:
     - python
     - numpy
     - matplotlib
     - python-weblogo
-    - mdanalysis >=0.11
+    - mdanalysis >=0.16
 
 test:
   imports:

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -21,7 +21,7 @@ Dependencies
     `matplotlib <http://matplotlib.org/>`_ [#]_ >= 1.4.0
         All ploting functions use the `matplotlib` package.
 
-    `MDAnalysis <http://www.mdanalysis.org/>`_ [#]_ >= 0.11
+    `MDAnalysis <http://www.mdanalysis.org/>`_ [#]_ >= 0.16
         We use MDAnalysis to read Gromacs molecular dynamics trajectories.
         Many other trajectory files are also supported, see list
         `here <https://pythonhosted.org/MDAnalysis/documentation_pages/coordinates/init.html#id1>`_.

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
 
     setup_requires=['pytest-runner'],
-    install_requires=['numpy', 'MDAnalysis>=0.11', 'matplotlib'],
+    install_requires=['numpy', 'MDAnalysis>=0.16', 'matplotlib'],
     tests_require=['pytest', 'pytest-raises', 'coverage'],
     # List additional groups of dependencies here
     # To install, use


### PR DESCRIPTION
We were asking for MDAnalysis >= 0.11, but that version is ancient and
the API changed rather drastically since then. I bumped the minimum
required version to 0.16. The tests run fine with version 0.17 that
should be preferred, especially on python 3.

@HubLot I do not know what should be done for the conda package to be rebuilt. It should now be possible to install PBxplore on python 3 with conda as MDAnalysis was the last obstacle.